### PR TITLE
docs: update minimum Rust version from 1.78 to 1.85

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thanks for your interest — we welcome contributions from everyone. Please read
 
 ## Development setup
 
-**Prerequisites:** Rust 1.78+, Node.js 20+, pnpm 9+.
+**Prerequisites:** Rust 1.85+, Node.js 20+, pnpm 9+.
 
 ```sh
 git clone https://github.com/thClaws/thClaws.git

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Supported: macOS (Apple Silicon & Intel), Windows (x86_64 & ARM64), Linux (x86_6
 
 ### Build from source
 
-**Prerequisites:** Rust 1.78+, Node.js 20+, pnpm 9+.
+**Prerequisites:** Rust 1.85+, Node.js 20+, pnpm 9+.
 
 ```sh
 git clone https://github.com/thClaws/thClaws.git


### PR DESCRIPTION
## Summary

Update minimum Rust version requirement from 1.78+ to 1.85+ in both `README.md` and `CONTRIBUTING.md`.

## Motivation

The `home` crate v0.5.12 (a transitive dependency) requires Rust edition 2024, which was stabilized in Rust 1.85. Building with Rust 1.78–1.84 fails with `feature 'edition2024' is required`. The documented prerequisite is outdated.

## Changes

- `README.md`: Rust 1.78+ → 1.85+
- `CONTRIBUTING.md`: Rust 1.78+ → 1.85+

## Test plan

- [x] Verified build fails with Rust 1.80.1 (`edition2024` error)
- [x] Verified build succeeds after upgrading to Rust 1.95.0

## Checklist

- [x] Documentation updated if behavior changes (README / CHANGELOG / in-repo docs)
- [x] No new compiler warnings introduced
- [x] PR scope is focused — no unrelated changes
- [x] Commits follow project style (concise, imperative, optional `feat/fix/docs/...` prefix)