### PR TITLE
fix(gui): remove duplicate sessions_list branch in Sidebar

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -85,8 +85,6 @@ export function Sidebar() {
         if (msg.kmss) {
           setKmss(msg.kmss as KmsInfo[]);
         }
-      } else if (msg.type === "sessions_list") {
-        setSessions(msg.sessions as SessionInfo[]);
       } else if (msg.type === "mcp_update") {
         setMcpServers(msg.servers as { name: string; tools: number }[]);
       } else if (msg.type === "kms_update") {


### PR DESCRIPTION
## Summary

Remove unreachable duplicate `sessions_list` handler in `Sidebar.tsx`.

## Motivation

The `sessions_list` message type was matched twice in the same if-else-if chain — at line 63 (with full `current_id` handling) and again at line 88 (without it). The second branch could never execute. ESLint reports this as `no-dupe-else-if`.

## Changes

- `frontend/src/components/Sidebar.tsx`: Remove the duplicate `else if (msg.type === "sessions_list")` branch (dead code removal, no behavior change)

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm lint` no longer reports `no-dupe-else-if` for Sidebar.tsx

## Checklist

- [x] No new compiler warnings introduced
- [x] PR scope is focused — no unrelated changes
- [x] Commits follow project style (concise, imperative, optional `feat/fix/docs/...` prefix)