### PR TITLE
fix: gitignore entire .thclaws/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ __pycache__/
 config.json
 .env
 .env.local
-.thclaws/sessions/
+.thclaws/
 
 # Local-only agent guidance (kept out of the public repo)
 CLAUDE.md


### PR DESCRIPTION
## Summary

Ignore the entire `.thclaws/` directory instead of only `.thclaws/sessions/`.

## Motivation

The `.thclaws/` directory contains per-user local config and runtime state (settings, sessions, team status, memory, todos, MCP config) — none of it should be committed. Previously only `sessions/` was ignored, leaving other runtime files (e.g. `team/agents/lead/status.json`) showing up in `git status` after running the app.

## Changes

- `.gitignore`: `.thclaws/sessions/` → `.thclaws/`

## Test plan

- [x] Run thClaws GUI, confirm `.thclaws/` files no longer appear in `git status`

## Checklist

- [x] No new compiler warnings introduced
- [x] PR scope is focused — no unrelated changes
- [x] Commits follow project style (concise, imperative, optional `feat/fix/docs/...` prefix)