### PR TITLE
fix(gui): resolve React lint errors in TerminalView and App

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -332,9 +332,7 @@ export default function App() {
     return unsub;
   }, []);
 
-  useEffect(() => {
-    if (!teamEnabled && activeTab === "team") setActiveTab("chat");
-  }, [teamEnabled, activeTab]);
+  const effectiveTab = (!teamEnabled && activeTab === "team") ? "chat" as Tab : activeTab;
 
   const TABS = teamEnabled ? ALL_TABS : ALL_TABS.filter((t) => t.id !== "team");
 
@@ -380,13 +378,13 @@ export default function App() {
             className="flex items-center gap-1.5 px-4 py-2 text-xs font-medium transition-colors"
             style={{
               color:
-                activeTab === tab.id
+                effectiveTab === tab.id
                   ? "var(--text-primary)"
                   : "var(--text-secondary)",
               background:
-                activeTab === tab.id ? "var(--bg-primary)" : "transparent",
+                effectiveTab === tab.id ? "var(--bg-primary)" : "transparent",
               borderBottom:
-                activeTab === tab.id
+                effectiveTab === tab.id
                   ? "2px solid var(--accent)"
                   : "2px solid transparent",
             }}
@@ -414,7 +412,7 @@ export default function App() {
               `display: none` — which zeroes xterm's grid and kills focus,
               making the terminal un-typeable after a tab switch. */}
           {TABS.map(({ id }) => {
-            const isActive = activeTab === id;
+            const isActive = effectiveTab === id;
             const cls = `absolute inset-0 ${isActive ? "" : "invisible pointer-events-none"}`;
             return (
               <div key={id} className={cls}>

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -50,7 +50,7 @@ export function TerminalView({ active }: Props) {
   const fitRef = useRef<FitAddon | null>(null);
   const { resolved: themeMode } = useTheme();
   const themeModeRef = useRef(themeMode);
-  themeModeRef.current = themeMode;
+  useEffect(() => { themeModeRef.current = themeMode; }, [themeMode]);
 
   useEffect(() => {
     if (!ref.current || termRef.current) return;
@@ -386,7 +386,7 @@ export function TerminalView({ active }: Props) {
       if (!e || e.contentRect.width === 0 || e.contentRect.height === 0) return;
       try {
         fit.fit();
-      } catch {}
+      } catch { /* fit() may throw on zero-size or disposed container */ }
     });
     ro.observe(ref.current);
 
@@ -406,7 +406,7 @@ export function TerminalView({ active }: Props) {
     const f = fitRef.current;
     if (!t) return;
     requestAnimationFrame(() => {
-      try { f?.fit(); } catch {}
+      try { f?.fit(); } catch { /* fit() may throw on zero-size or disposed container */ }
       t.focus();
     });
   }, [active]);


### PR DESCRIPTION
## Summary

Fix three React-related ESLint errors in TerminalView and App components.

## Motivation

`pnpm lint` reports errors for ref writes during render, setState inside useEffect, and empty catch blocks. These are React anti-patterns that can cause subtle rendering issues.

## Changes

- `TerminalView.tsx`: Move `themeModeRef` update into `useEffect` to avoid ref writes during render (`react-hooks/refs`)
- `App.tsx`: Replace `setState`-in-`useEffect` with a derived `effectiveTab` variable to avoid cascading renders (`react-hooks/set-state-in-effect`)
- `TerminalView.tsx`: Add comments to empty catch blocks in `fit()` calls (`no-empty`)

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm lint` — all three errors resolved
- [x] Manually tested:
  1. Terminal theme switch (Light/Dark) — colors update immediately
  2. Team tab toggle off while on Team tab — falls back to Chat tab
  3. Terminal tab switch + window resize — terminal refits correctly

## Checklist

- [x] No new compiler warnings introduced
- [x] PR scope is focused — no unrelated changes
- [x] Commits follow project style (concise, imperative, optional `feat/fix/docs/...` prefix)