### PR TITLE
fix(gui): improve type safety and resolve lint errors

### DIFF
--- a/frontend/src/components/TeamView.tsx
+++ b/frontend/src/components/TeamView.tsx
@@ -27,6 +27,7 @@ const ANSI_PALETTES: Record<ResolvedTheme, Record<number, string>> = {
 // line sits flush with its neighbours. Errors (`✗`) are never collapsed —
 // they're worth seeing individually.
 function collapseToolRuns(lines: string[]): string[] {
+  // eslint-disable-next-line no-control-regex
   const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
   const okRe = /\[tool:\s*(\w+)\][^\n]*?✓/;
 
@@ -74,6 +75,7 @@ function ansiToHtml(text: string, palette: Record<number, string>): string {
   // Parse ANSI escape sequences into balanced <span> tags.
   let out = "";
   let open = 0;
+  // eslint-disable-next-line no-control-regex
   const re = /\x1b\[([0-9;]*)m/g;
   let last = 0;
   let m: RegExpExecArray | null;
@@ -117,11 +119,11 @@ export function TeamView() {
     const unsub = subscribe((msg) => {
       if (msg.type === "team_status" && Array.isArray(msg.agents)) {
         setAgents(
-          msg.agents.map((a: any) => ({
-            name: a.name || a.agent || "?",
-            status: a.status || "unknown",
-            task: a.task || a.current_task || null,
-            output: a.output || [],
+          msg.agents.map((a: Record<string, unknown>): AgentInfo => ({
+            name: String(a.name || a.agent || "?"),
+            status: String(a.status || "unknown"),
+            task: a.task ? String(a.task) : a.current_task ? String(a.current_task) : null,
+            output: Array.isArray(a.output) ? a.output as string[] : [],
           }))
         );
       } else if (

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -1,0 +1,11 @@
+/** Global type augmentations for the wry WebView IPC bridge. */
+declare global {
+  interface Window {
+    /** Injected by wry — posts JSON messages to the Rust backend. */
+    ipc?: { postMessage(msg: string): void };
+    /** Registered by useIPC — called by Rust via evaluate_script. */
+    __thclaws_dispatch?: (json: string) => void;
+  }
+}
+
+export {};

--- a/frontend/src/hooks/useIPC.ts
+++ b/frontend/src/hooks/useIPC.ts
@@ -15,8 +15,8 @@ export type IPCMessage = {
 
 // Send a message to Rust
 export function send(msg: IPCMessage) {
-  if ((window as any).ipc) {
-    (window as any).ipc.postMessage(JSON.stringify(msg));
+  if (window.ipc) {
+    window.ipc.postMessage(JSON.stringify(msg));
   } else {
     console.warn("[ipc] no backend — running in browser dev mode?", msg);
   }
@@ -32,7 +32,7 @@ export function subscribe(handler: Handler): () => void {
 }
 
 // Called by Rust via evaluate_script
-(window as any).__thclaws_dispatch = (json: string) => {
+window.__thclaws_dispatch = (json: string) => {
   try {
     const msg: IPCMessage = JSON.parse(json);
     handlers.forEach((h) => h(msg));


### PR DESCRIPTION
## Summary

Fix type safety issues and lint errors across frontend IPC layer and TeamView.

## Motivation

`pnpm lint` reports `@typescript-eslint/no-explicit-any` errors in `useIPC.ts` and `TeamView.tsx`, and `no-control-regex` errors for intentional ANSI escape regex patterns.

## Changes

- `frontend/src/global.d.ts`: New file — declares `Window.ipc` and `Window.__thclaws_dispatch` types for the wry WebView IPC bridge
- `frontend/src/hooks/useIPC.ts`: Replace `(window as any)` casts with typed `window.ipc` / `window.__thclaws_dispatch`
- `frontend/src/components/TeamView.tsx`: Replace `any` with `Record<string, unknown>` and explicit type conversions; add `eslint-disable` for intentional ANSI escape regex

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm lint` — all `no-explicit-any` and `no-control-regex` errors resolved
- [x] Manually tested:
  1. Terminal — commands work via IPC
  2. Chat — messages send and receive correctly
  3. Sidebar — session list displays and updates

## Checklist

- [x] No new compiler warnings introduced
- [x] PR scope is focused — no unrelated changes
- [x] Commits follow project style (concise, imperative, optional `feat/fix/docs/...` prefix)