### PR TITLE
refactor(gui): split ThemeProvider out of useTheme hook

### DIFF
--- a/frontend/src/components/ThemeProvider.tsx
+++ b/frontend/src/components/ThemeProvider.tsx
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { send, subscribe } from "../hooks/useIPC";
+import {
+  ThemeContext,
+  detectSystem,
+  type ThemeMode,
+  type ResolvedTheme,
+} from "../hooks/useTheme";
+
+function normalize(raw: unknown): ThemeMode {
+  return raw === "light" || raw === "dark" ? raw : "system";
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [mode, setModeState] = useState<ThemeMode>("system");
+  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(() =>
+    detectSystem(),
+  );
+
+  useEffect(() => {
+    const unsub = subscribe((msg) => {
+      if (msg.type === "theme") {
+        setModeState(normalize(msg.mode));
+      }
+    });
+    send({ type: "theme_get" });
+    return unsub;
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia("(prefers-color-scheme: light)");
+    const onChange = () => setSystemTheme(mql.matches ? "light" : "dark");
+    // Safari < 14 still uses addListener; guard for both.
+    if (mql.addEventListener) mql.addEventListener("change", onChange);
+    else mql.addListener(onChange);
+    return () => {
+      if (mql.removeEventListener) mql.removeEventListener("change", onChange);
+      else mql.removeListener(onChange);
+    };
+  }, []);
+
+  const resolved: ResolvedTheme = mode === "system" ? systemTheme : mode;
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-theme", resolved);
+  }, [resolved]);
+
+  const setMode = useCallback((next: ThemeMode) => {
+    setModeState(next);
+    send({ type: "theme_set", mode: next });
+  }, []);
+
+  const value = useMemo(
+    () => ({ mode, resolved, setMode }),
+    [mode, resolved, setMode],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}

--- a/frontend/src/hooks/useTheme.tsx
+++ b/frontend/src/hooks/useTheme.tsx
@@ -1,17 +1,9 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
-import { send, subscribe } from "./useIPC";
+import { createContext, useContext } from "react";
 
 export type ThemeMode = "light" | "dark" | "system";
 export type ResolvedTheme = "light" | "dark";
 
-type ThemeContextValue = {
+export type ThemeContextValue = {
   /** User's stored preference — may be "system". */
   mode: ThemeMode;
   /** Concrete theme currently applied ("light" | "dark"). */
@@ -20,65 +12,13 @@ type ThemeContextValue = {
   setMode: (m: ThemeMode) => void;
 };
 
-const ThemeContext = createContext<ThemeContextValue | null>(null);
+export const ThemeContext = createContext<ThemeContextValue | null>(null);
 
-function detectSystem(): ResolvedTheme {
+export function detectSystem(): ResolvedTheme {
   if (typeof window === "undefined" || !window.matchMedia) return "dark";
   return window.matchMedia("(prefers-color-scheme: light)").matches
     ? "light"
     : "dark";
-}
-
-function normalize(raw: unknown): ThemeMode {
-  return raw === "light" || raw === "dark" ? raw : "system";
-}
-
-export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [mode, setModeState] = useState<ThemeMode>("system");
-  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(() =>
-    detectSystem(),
-  );
-
-  useEffect(() => {
-    const unsub = subscribe((msg) => {
-      if (msg.type === "theme") {
-        setModeState(normalize(msg.mode));
-      }
-    });
-    send({ type: "theme_get" });
-    return unsub;
-  }, []);
-
-  useEffect(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return;
-    const mql = window.matchMedia("(prefers-color-scheme: light)");
-    const onChange = () => setSystemTheme(mql.matches ? "light" : "dark");
-    // Safari < 14 still uses addListener; guard for both.
-    if (mql.addEventListener) mql.addEventListener("change", onChange);
-    else mql.addListener(onChange);
-    return () => {
-      if (mql.removeEventListener) mql.removeEventListener("change", onChange);
-      else mql.removeListener(onChange);
-    };
-  }, []);
-
-  const resolved: ResolvedTheme = mode === "system" ? systemTheme : mode;
-
-  useEffect(() => {
-    document.documentElement.setAttribute("data-theme", resolved);
-  }, [resolved]);
-
-  const setMode = useCallback((next: ThemeMode) => {
-    setModeState(next);
-    send({ type: "theme_set", mode: next });
-  }, []);
-
-  const value = useMemo(
-    () => ({ mode, resolved, setMode }),
-    [mode, resolved, setMode],
-  );
-
-  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }
 
 export function useTheme(): ThemeContextValue {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App";
-import { ThemeProvider } from "./hooks/useTheme";
+import { ThemeProvider } from "./components/ThemeProvider";
 
 // Apply the OS-preferred theme synchronously before React mounts, so the
 // first paint of the startup modal already honours the user's light/dark


### PR DESCRIPTION
## Summary

Move ThemeProvider component out of `hooks/useTheme.tsx` into its own file at `components/ThemeProvider.tsx`.

## Motivation

ESLint `react-refresh/only-export-components` reports an error when a file exports both components and non-component functions, because React fast refresh cannot reliably hot-reload mixed exports. Splitting the provider into its own file resolves this.

## Changes

- `frontend/src/hooks/useTheme.tsx`: Remove ThemeProvider component; keep hook, types, and context
- `frontend/src/components/ThemeProvider.tsx`: New file — ThemeProvider component extracted here
- `frontend/src/main.tsx`: Update import path for ThemeProvider

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm lint` — `react-refresh/only-export-components` error resolved
- [x] Manually tested:
  1. Switch theme (Light/Dark/System) — colors update immediately
  2. Close and reopen app — theme preference persists

## Checklist

- [x] No new compiler warnings introduced
- [x] PR scope is focused — no unrelated changes
- [x] Commits follow project style (concise, imperative, optional `feat/fix/docs/...` prefix)