### PR TITLE
fix(gui): resolve react-hooks/exhaustive-deps warnings

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Terminal, MessageSquare, FolderTree, Users, FolderOpen, Folder, Settings } from "lucide-react";
 import { TerminalView } from "./components/TerminalView";
 import { ChatView } from "./components/ChatView";
@@ -294,6 +294,7 @@ export default function App() {
   const [showSettingsMenu, setShowSettingsMenu] = useState(false);
   const [instructionsScope, setInstructionsScope] =
     useState<"global" | "folder" | null>(null);
+  const closeInstructions = useCallback(() => setInstructionsScope(null), []);
   // Secrets-backend gate: we ask once at first launch so the app
   // never touches the OS keychain behind the user's back. `null` ==
   // not picked yet → show the chooser before the main UI.
@@ -483,7 +484,7 @@ export default function App() {
       {instructionsScope && (
         <InstructionsEditorModal
           scope={instructionsScope}
-          onClose={() => setInstructionsScope(null)}
+          onClose={closeInstructions}
         />
       )}
       <ApprovalModal />

--- a/frontend/src/components/FilesView.tsx
+++ b/frontend/src/components/FilesView.tsx
@@ -186,6 +186,10 @@ export function FilesView({ active }: Props) {
       }
     }, 2000);
     return () => clearInterval(interval);
+  // `preview?.path` is intentional — using the full `preview` object
+  // would re-run on every polling cycle (setPreview creates a new
+  // reference each time), resetting the interval unnecessarily.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active, currentPath, preview?.path, mode, themeMode]);
 
   const navigate = (name: string) => {

--- a/frontend/src/components/InstructionsEditorModal.tsx
+++ b/frontend/src/components/InstructionsEditorModal.tsx
@@ -178,7 +178,7 @@ export function InstructionsEditorModal({
     });
     send({ type: "instructions_get", scope });
     return unsub;
-  }, [scope, editor]);
+  }, [scope, editor, onClose]);
 
   const handleSave = () => {
     if (!editor) return;


### PR DESCRIPTION
## Summary

Resolve two `react-hooks/exhaustive-deps` warnings in FilesView and InstructionsEditorModal.

## Motivation

`pnpm lint` reports missing dependencies in useEffect hooks. These are the last remaining lint warnings in the frontend.

## Changes

- `frontend/src/App.tsx`: Wrap InstructionsEditorModal's `onClose` callback in `useCallback` to provide a stable reference
- `frontend/src/components/InstructionsEditorModal.tsx`: Add `onClose` to useEffect dependency array (safe now that the reference is stable)
- `frontend/src/components/FilesView.tsx`: Add `eslint-disable` with comment explaining why `preview?.path` is used instead of `preview` — the full object would cause the effect to re-run on every 2s polling cycle since `setPreview` creates a new reference each time

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm lint` passes with zero errors and zero warnings
- [x] Manually tested:
  1. Files tab — click to switch between files, preview updates correctly every time
  2. Instructions editor — edit and save, modal closes on success

## Checklist

- [x] No new compiler warnings introduced
- [x] PR scope is focused — no unrelated changes
- [x] Commits follow project style (concise, imperative, optional `feat/fix/docs/...` prefix)