### PR TITLE
docs(frontend): Document thClaws frontend

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,73 +1,102 @@
-# React + TypeScript + Vite
+# thClaws Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This directory contains the React frontend for the thClaws desktop GUI. It is
+not a standalone web app in production: the Vite build is emitted as a
+single-file bundle, then embedded into the Rust GUI binary and served inside a
+`wry` webview.
 
-Currently, two official plugins are available:
+## How It Fits Together
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+- React + TypeScript renders the desktop interface: Chat, Terminal, Files,
+  Settings, and Team views.
+- Vite builds `frontend/dist/index.html` with JavaScript and CSS inlined via
+  `vite-plugin-singlefile`.
+- The Rust GUI embeds that file at compile time and serves it through a custom
+  `thclaws://` protocol.
+- Both the Chat and Terminal tabs talk to the same Rust-side agent session, so
+  they share conversation history, model state, tools, and saved sessions.
 
-## React Compiler
+## Important Files
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+- `src/App.tsx` — main app shell, startup flow, tab layout, settings modals,
+  and working-directory selection.
+- `src/components/` — UI surfaces for chat, terminal, file browser/editor,
+  settings, approvals, sidebar, and team panes.
+- `src/hooks/useIPC.ts` — JSON message bridge between React and the Rust
+  backend.
+- `src/index.css` — global styles, Tailwind import, theme variables, and shared
+  UI styling.
+- `vite.config.ts` — Vite config, including React, Tailwind, and single-file
+  bundling.
 
-## Expanding the ESLint configuration
+## IPC Contract
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+The frontend and Rust backend communicate with small JSON messages.
 
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
+React sends messages to Rust through:
 
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```ts
+window.ipc.postMessage(JSON.stringify({ type: "chat_prompt", text }));
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Rust sends messages back by evaluating:
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+```ts
+window.__thclaws_dispatch(JSON.stringify({ type: "chat_text_delta", text }));
+```
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+React components subscribe through `src/hooks/useIPC.ts`, which parses the
+incoming JSON and fans it out to local handlers.
+
+## Development Commands
+
+Install dependencies:
+
+```sh
+pnpm install
+```
+
+Run the Vite dev server:
+
+```sh
+pnpm dev
+```
+
+Build the production bundle:
+
+```sh
+pnpm build
+```
+
+Lint the frontend:
+
+```sh
+pnpm lint
+```
+
+Preview the built bundle:
+
+```sh
+pnpm preview
+```
+
+## Building the Desktop GUI
+
+The Rust GUI expects `frontend/dist/index.html` to exist because it is embedded
+with `include_str!` during compilation. Build the frontend before compiling the
+GUI binary:
+
+```sh
+cd frontend
+pnpm install
+pnpm build
+cd ..
+cargo build --features gui --bin thclaws
+```
+
+For local GUI runs, use the same ordering:
+
+```sh
+cd frontend && pnpm build && cd ..
+cargo run --features gui --bin thclaws
 ```


### PR DESCRIPTION
## Summary

Replace the default Vite template README with thClaws-specific frontend documentation.

ภาษาไทย: PR นี้เปลี่ยน `frontend/README.md` จาก README template ของ Vite ให้เป็นเอกสารที่อธิบาย frontend ของ thClaws จริง ๆ

## Motivation

Help new contributors understand how the React frontend connects to the Rust GUI backend.

ภาษาไทย: จุดประสงค์คือช่วย contributor ใหม่เข้าใจภาพรวมของ React GUI, การ embed ผ่าน Rust `wry`, และ flow การสื่อสารผ่าน IPC ก่อนเริ่มแก้ frontend

## Changes

- Document the React + Vite single-file frontend bundle
- Explain Rust `wry` embedding and the IPC bridge
- List important frontend files and development commands
- Document the required frontend build order before compiling the GUI

ภาษาไทย: สิ่งที่เพิ่มคือคำอธิบายโครงสร้าง frontend, ไฟล์สำคัญ, วิธี dev/build, การ build bundle แบบ single-file, และลำดับที่ต้อง build frontend ก่อน compile GUI binary

## Test plan

How did you verify this works?

- [ ] `cargo test --features gui` passes locally — not run, docs-only change
- [ ] `cargo fmt --check` passes — not run, docs-only change
- [ ] `cargo clippy --features gui -- -D warnings` passes — not run, docs-only change
- [ ] Frontend type-check passes (`cd frontend && pnpm tsc --noEmit`) — not run, docs-only change
- [x] Manually checked the README against `frontend/package.json` and `frontend/vite.config.ts`
- [x] `git diff --check` passes locally

ภาษาไทย: ไม่ได้รัน full build/test เพราะ PR นี้แก้เฉพาะเอกสาร ไม่มีการเปลี่ยน code หรือ runtime behavior

## Screenshots / recordings

Not applicable, docs-only change.

ภาษาไทย: ไม่มี screenshot เพราะไม่ได้เปลี่ยน UI

## Checklist

- [ ] Tests added or updated — not applicable, docs-only change
- [x] Documentation updated
- [x] No new compiler warnings introduced
- [x] PR scope is focused — no unrelated changes
- [x] Commits follow project style
