### PR TITLE
fix: handle GUI ask prompts and macOS close shortcuts

### DIFF
--- a/crates/core/src/gui.rs
+++ b/crates/core/src/gui.rs
@@ -22,8 +22,12 @@ use base64::Engine;
 use std::borrow::Cow;
 use std::sync::Arc;
 use tao::dpi::LogicalSize;
+#[cfg(target_os = "macos")]
+use tao::event::ElementState;
 use tao::event::{Event, WindowEvent};
 use tao::event_loop::{ControlFlow, EventLoopBuilder, EventLoopProxy};
+#[cfg(target_os = "macos")]
+use tao::keyboard::{Key, ModifiersState};
 use tao::window::WindowBuilder;
 use wry::http::Response;
 use wry::WebViewBuilder;
@@ -65,6 +69,7 @@ enum UserEvent {
     SessionListRefresh(String),
     FileTree(String),
     FileContent(String),
+    QuitRequested,
 }
 
 const MAX_RECENT_DIRS: usize = 3;
@@ -794,6 +799,26 @@ fn escape_for_js(s: &str) -> String {
         .replace('\r', "\\r")
 }
 
+#[cfg(target_os = "macos")]
+fn is_macos_close_shortcut(event: &tao::event::KeyEvent, modifiers: ModifiersState) -> bool {
+    if event.state != ElementState::Pressed || !modifiers.super_key() {
+        return false;
+    }
+    match event.key_without_modifiers() {
+        Key::Character(ch) => ch.eq_ignore_ascii_case("q") || ch.eq_ignore_ascii_case("w"),
+        _ => false,
+    }
+}
+
+fn request_gui_shutdown(shared: &SharedSessionHandle, control_flow: &mut ControlFlow) {
+    let _ = shared.input_tx.send(ShellInput::SaveAndQuit);
+    // Kill any spawned teammate processes.
+    let _ = std::process::Command::new("pkill")
+        .args(["-f", "team-agent"])
+        .status();
+    *control_flow = ControlFlow::Exit;
+}
+
 pub fn run_gui() {
     let event_loop = EventLoopBuilder::<UserEvent>::with_user_event().build();
     let proxy = event_loop.create_proxy();
@@ -830,6 +855,39 @@ pub fn run_gui() {
     spawn_event_translator(&shared, proxy.clone());
     let shared_for_ipc = shared.clone();
     let shared_for_events = shared.clone();
+    let (ask_tx, mut ask_rx) =
+        tokio::sync::mpsc::unbounded_channel::<crate::tools::AskUserRequest>();
+    crate::tools::set_gui_ask_sender(Some(ask_tx));
+    let pending_asks = Arc::new(std::sync::Mutex::new(std::collections::HashMap::<
+        u64,
+        tokio::sync::oneshot::Sender<String>,
+    >::new()));
+    let pending_asks_for_ipc = pending_asks.clone();
+
+    // Forwarder: AskUserQuestion tool calls -> frontend composer handoff.
+    let proxy_for_ask = proxy.clone();
+    let pending_asks_for_forwarder = pending_asks.clone();
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("ask-user forwarder runtime");
+        rt.block_on(async move {
+            while let Some(req) = ask_rx.recv().await {
+                let id = req.id;
+                let question = req.question.clone();
+                if let Ok(mut pending) = pending_asks_for_forwarder.lock() {
+                    pending.insert(id, req.response);
+                }
+                let payload = serde_json::json!({
+                    "type": "ask_user_question",
+                    "id": id,
+                    "question": question,
+                });
+                let _ = proxy_for_ask.send_event(UserEvent::Dispatch(payload.to_string()));
+            }
+        });
+    });
 
     // Forwarder: approval requests → frontend dispatches. Spawned on a
     // dedicated tokio runtime thread so we can `await` the mpsc without
@@ -967,6 +1025,24 @@ pub fn run_gui() {
             let ty = msg.get("type").and_then(|t| t.as_str()).unwrap_or("");
 
             match ty {
+                "app_close" => {
+                    let _ = proxy_for_ipc.send_event(UserEvent::QuitRequested);
+                }
+                "ask_user_response" => {
+                    let id = msg.get("id").and_then(|v| v.as_u64()).unwrap_or(0);
+                    let text = msg
+                        .get("text")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let responder = pending_asks_for_ipc
+                        .lock()
+                        .ok()
+                        .and_then(|mut pending| pending.remove(&id));
+                    if let Some(responder) = responder {
+                        let _ = responder.send(text);
+                    }
+                }
                 "get_cwd" => {
                     let cwd = std::env::current_dir()
                         .map(|p| p.to_string_lossy().to_string())
@@ -2037,6 +2113,9 @@ pub fn run_gui() {
         .build_gtk(window.default_vbox().unwrap())
         .expect("webview build (gtk)");
 
+    #[cfg(target_os = "macos")]
+    let mut macos_modifiers = ModifiersState::empty();
+
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
 
@@ -2107,17 +2186,28 @@ pub fn run_gui() {
                 );
                 let _ = webview.evaluate_script(&js);
             }
+            Event::UserEvent(UserEvent::QuitRequested) => {
+                request_gui_shutdown(&shared_for_events, control_flow);
+            }
+            #[cfg(target_os = "macos")]
+            Event::WindowEvent {
+                event: WindowEvent::ModifiersChanged(modifiers),
+                ..
+            } => {
+                macos_modifiers = modifiers;
+            }
+            #[cfg(target_os = "macos")]
+            Event::WindowEvent {
+                event: WindowEvent::KeyboardInput { event, .. },
+                ..
+            } if is_macos_close_shortcut(&event, macos_modifiers) => {
+                request_gui_shutdown(&shared_for_events, control_flow);
+            }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 ..
             } => {
-                // Save the shared session before exit.
-                let _ = shared_for_events.input_tx.send(ShellInput::SaveAndQuit);
-                // Kill any spawned teammate processes.
-                let _ = std::process::Command::new("pkill")
-                    .args(["-f", "team-agent"])
-                    .status();
-                *control_flow = ControlFlow::Exit;
+                request_gui_shutdown(&shared_for_events, control_flow);
             }
             _ => {}
         }

--- a/crates/core/src/shared_session.rs
+++ b/crates/core/src/shared_session.rs
@@ -1454,6 +1454,13 @@ fn format_tool_label(name: &str, input: &serde_json::Value) -> String {
             .get("query")
             .and_then(|v| v.as_str())
             .map(|q| format!("({q})")),
+        "AskUserQuestion" => input.get("question").and_then(|v| v.as_str()).map(|q| {
+            let first: String = q.chars().take(60).collect();
+            format!(
+                "({first}{})",
+                if q.chars().count() > 60 { "..." } else { "" }
+            )
+        }),
         _ => None,
     }
     .unwrap_or_default();

--- a/crates/core/src/tools/ask.rs
+++ b/crates/core/src/tools/ask.rs
@@ -2,8 +2,43 @@ use super::{req_str, Tool};
 use crate::error::Result;
 use async_trait::async_trait;
 use serde_json::{json, Value};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+use tokio::sync::{mpsc, oneshot};
 
 pub struct AskUserTool;
+
+pub struct AskUserRequest {
+    pub id: u64,
+    pub question: String,
+    pub response: oneshot::Sender<String>,
+}
+
+static NEXT_ASK_ID: AtomicU64 = AtomicU64::new(1);
+static GUI_ASK_SENDER: OnceLock<Mutex<Option<mpsc::UnboundedSender<AskUserRequest>>>> =
+    OnceLock::new();
+
+pub fn set_gui_ask_sender(sender: Option<mpsc::UnboundedSender<AskUserRequest>>) {
+    let slot = GUI_ASK_SENDER.get_or_init(|| Mutex::new(None));
+    if let Ok(mut guard) = slot.lock() {
+        *guard = sender;
+    }
+}
+
+fn gui_ask_sender() -> Option<mpsc::UnboundedSender<AskUserRequest>> {
+    GUI_ASK_SENDER
+        .get()
+        .and_then(|slot| slot.lock().ok().and_then(|guard| guard.clone()))
+}
+
+fn normalize_answer(answer: String) -> String {
+    let trimmed = answer.trim().to_string();
+    if trimmed.is_empty() {
+        "(no response from user)".to_string()
+    } else {
+        trimmed
+    }
+}
 
 #[async_trait]
 impl Tool for AskUserTool {
@@ -36,6 +71,21 @@ impl Tool for AskUserTool {
 
     async fn call(&self, input: Value) -> Result<String> {
         let question = req_str(&input, "question")?.to_string();
+        if let Some(sender) = gui_ask_sender() {
+            let id = NEXT_ASK_ID.fetch_add(1, Ordering::Relaxed);
+            let (response, answer_rx) = oneshot::channel();
+            if sender
+                .send(AskUserRequest {
+                    id,
+                    question: question.clone(),
+                    response,
+                })
+                .is_ok()
+            {
+                return Ok(normalize_answer(answer_rx.await.unwrap_or_default()));
+            }
+        }
+
         let answer = tokio::task::spawn_blocking(move || {
             use std::io::{BufRead, Write};
             println!("\n\x1b[36m[agent asks]: {question}\x1b[0m");
@@ -48,10 +98,32 @@ impl Tool for AskUserTool {
         .await
         .unwrap_or_default();
 
-        if answer.is_empty() {
-            Ok("(no response from user)".to_string())
-        } else {
-            Ok(answer)
-        }
+        Ok(normalize_answer(answer))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::Tool;
+
+    #[tokio::test]
+    async fn gui_ask_sender_round_trips_answer() {
+        let (sender, mut requests) = mpsc::unbounded_channel();
+        set_gui_ask_sender(Some(sender));
+
+        let pending = tokio::spawn(async {
+            AskUserTool
+                .call(json!({ "question": "Ready?" }))
+                .await
+                .expect("ask call")
+        });
+
+        let req = requests.recv().await.expect("ask request");
+        assert_eq!(req.question, "Ready?");
+        req.response.send("yes".to_string()).expect("send response");
+
+        assert_eq!(pending.await.expect("join ask"), "yes");
+        set_gui_ask_sender(None);
     }
 }

--- a/crates/core/src/tools/mod.rs
+++ b/crates/core/src/tools/mod.rs
@@ -27,7 +27,7 @@ pub mod todo;
 pub mod web;
 pub mod write;
 
-pub use ask::AskUserTool;
+pub use ask::{set_gui_ask_sender, AskUserRequest, AskUserTool};
 pub use bash::BashTool;
 pub use edit::EditTool;
 pub use glob::GlobTool;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -287,6 +287,20 @@ export default function App() {
   // to paste.
   useEditingShortcuts();
 
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!navigator.platform.startsWith("Mac")) return;
+      if (!e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+      const key = e.key.toLowerCase();
+      if (key !== "q" && key !== "w") return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      send({ type: "app_close" });
+    };
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    return () => window.removeEventListener("keydown", onKeyDown, { capture: true });
+  }, []);
+
   const [started, setStarted] = useState(false);
   const [currentCwd, setCurrentCwd] = useState("");
   const [activeTab, setActiveTab] = useState<Tab>("terminal");

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -29,6 +29,11 @@ type Attachment = {
   previewUrl: string;
 };
 
+type AskPrompt = {
+  id: number;
+  question: string;
+};
+
 const SUPPORTED_IMAGE_MIME = /^image\/(png|jpeg|jpg|webp|gif)$/;
 const MAX_IMAGE_BYTES = 10 * 1024 * 1024; // 10 MB per attachment
 
@@ -57,6 +62,7 @@ export function ChatView() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
   const [streaming, setStreaming] = useState(false);
+  const [askPrompt, setAskPrompt] = useState<AskPrompt | null>(null);
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [dragActive, setDragActive] = useState(false);
   const [copiedMessageIndex, setCopiedMessageIndex] = useState<number | null>(
@@ -123,6 +129,7 @@ export function ChatView() {
   };
 
   const onPaste = (e: React.ClipboardEvent) => {
+    if (askPrompt) return;
     const items = e.clipboardData?.items;
     if (!items) return;
     for (const item of Array.from(items)) {
@@ -138,6 +145,7 @@ export function ChatView() {
 
   const onDragOver = (e: React.DragEvent) => {
     e.preventDefault();
+    if (askPrompt) return;
     if (!dragActive) setDragActive(true);
   };
 
@@ -149,6 +157,7 @@ export function ChatView() {
   const onDrop = (e: React.DragEvent) => {
     e.preventDefault();
     setDragActive(false);
+    if (askPrompt) return;
     const files = e.dataTransfer?.files;
     if (!files) return;
     for (const file of Array.from(files)) {
@@ -208,9 +217,15 @@ export function ChatView() {
           // bubbles via chat_text_delta-like paths; that's separate
           // from normal tool completion.)
           setMessages((prev) => {
-            const last = prev[prev.length - 1];
-            if (last && last.role === "tool") {
-              return [...prev.slice(0, -1), { ...last, toolDone: true }];
+            for (let i = prev.length - 1; i >= 0; i--) {
+              const candidate = prev[i];
+              if (candidate.role === "tool" && !candidate.toolDone) {
+                return [
+                  ...prev.slice(0, i),
+                  { ...candidate, toolDone: true },
+                  ...prev.slice(i + 1),
+                ];
+              }
             }
             return prev;
           });
@@ -223,10 +238,22 @@ export function ChatView() {
           break;
         case "chat_done":
           setStreaming(false);
+          setAskPrompt(null);
           break;
+        case "ask_user_question": {
+          const id = typeof msg.id === "number" ? msg.id : null;
+          const question = typeof msg.question === "string" ? msg.question : "";
+          if (id !== null) {
+            setAskPrompt({ id, question });
+            setStreaming(true);
+            setAttachments([]);
+          }
+          break;
+        }
         case "new_session_ack":
           setMessages([]);
           setStreaming(false);
+          setAskPrompt(null);
           break;
         case "chat_history_replaced":
           if (msg.messages && Array.isArray(msg.messages)) {
@@ -258,6 +285,7 @@ export function ChatView() {
               ),
             );
             setStreaming(false);
+            setAskPrompt(null);
           }
           break;
       }
@@ -283,6 +311,14 @@ export function ChatView() {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const text = input.trim();
+    if (askPrompt) {
+      if (!text) return;
+      setInput("");
+      send({ type: "ask_user_response", id: askPrompt.id, text });
+      setMessages((prev) => [...prev, { role: "user", content: text }]);
+      setAskPrompt(null);
+      return;
+    }
     // Allow send when EITHER text or attachments are present —
     // "describe this image" with no text is a valid use case.
     if ((!text && attachments.length === 0) || streaming) return;
@@ -290,15 +326,14 @@ export function ChatView() {
     const pendingAttachments = attachments;
     setAttachments([]);
 
-    // /exit and /quit close the window — handle locally so we get the
-    // window.close after the backend save round-trip. Everything else
+    // /exit and /quit close the app through the backend so it can save
+    // the shared session before the tao event loop exits. Everything else
     // (including /clear, /help, every other slash command) goes to the
     // shared session, which dispatches it and broadcasts the response
     // back as a `chat_slash_output` system bubble.
     const lower = text.toLowerCase();
     if (lower === "/exit" || lower === "/quit" || lower === "/q") {
-      send({ type: "new_session" });
-      setTimeout(() => window.close(), 200);
+      send({ type: "app_close" });
       return;
     }
 
@@ -315,6 +350,21 @@ export function ChatView() {
       })),
     });
   };
+
+  const awaitingUserAnswer = askPrompt !== null;
+  const inputDisabled = streaming && !awaitingUserAnswer;
+  const submitDisabled = awaitingUserAnswer
+    ? !input.trim()
+    : streaming || (!input.trim() && attachments.length === 0);
+  const inputPlaceholder = awaitingUserAnswer
+    ? askPrompt.question
+      ? `Answer: ${askPrompt.question}`
+      : "Answer the assistant..."
+    : streaming
+      ? "Waiting for response..."
+      : attachments.length > 0
+        ? "Add a prompt (or send as-is)..."
+        : "Type a message — paste or drop an image to attach...";
 
   return (
     <div className="flex flex-col h-full">
@@ -520,14 +570,8 @@ export function ChatView() {
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onPaste={onPaste}
-            placeholder={
-              streaming
-                ? "Waiting for response..."
-                : attachments.length > 0
-                  ? "Add a prompt (or send as-is)..."
-                  : "Type a message — paste or drop an image to attach..."
-            }
-            disabled={streaming}
+            placeholder={inputPlaceholder}
+            disabled={inputDisabled}
             className="flex-1 px-3 py-2 rounded text-sm outline-none"
             style={{
               background: "var(--bg-tertiary)",
@@ -537,15 +581,15 @@ export function ChatView() {
           />
           <button
             type="submit"
-            disabled={streaming || (!input.trim() && attachments.length === 0)}
+            disabled={submitDisabled}
             className="px-4 py-2 rounded text-sm font-medium transition-colors"
             style={{
-              background: streaming ? "var(--bg-tertiary)" : "var(--accent)",
-              color: streaming ? "var(--text-secondary)" : "var(--accent-fg)",
-              cursor: streaming ? "not-allowed" : "pointer",
+              background: submitDisabled ? "var(--bg-tertiary)" : "var(--accent)",
+              color: submitDisabled ? "var(--text-secondary)" : "var(--accent-fg)",
+              cursor: submitDisabled ? "not-allowed" : "pointer",
             }}
           >
-            Send
+            {awaitingUserAnswer ? "Reply" : "Send"}
           </button>
         </div>
       </form>


### PR DESCRIPTION
## Summary
- Add a GUI bridge for `AskUserQuestion` so the frontend can accept and return user replies while an agent is waiting.
- Route macOS close shortcuts (`Cmd+Q`, `Cmd+W`) and `/quit` style chat commands through the backend shutdown path.
- Keep AskUser tool labels visible in chat history and finish pending tool bubbles even after the user reply is inserted.

## Motivation
The GUI could get stuck in a waiting state when an agent asked the user a question, leaving the composer disabled. On macOS fullscreen, close/quit shortcuts were also not reliably reaching the app shutdown flow.

## Changes
- Registered an AskUser request sender for GUI sessions and forwarded questions to the webview via user events.
- Added IPC handling for `ask_user_response` and `app_close`.
- Made the chat composer enter a reply mode while `AskUserQuestion` is pending.
- Added macOS keyboard handling for `Cmd+Q` and `Cmd+W` in both the webview and tao event loop.

## Test plan
- [x] `cargo test --features gui` passes locally.
- [x] `cargo fmt --check` passes.
- [x] `pnpm build` passes in `frontend` (includes `tsc -b`).
- [x] `pnpm lint` passes in `frontend`.
- [ ] `cargo clippy --features gui -- -D warnings` passes. This currently fails on pre-existing clippy lints with Rust 1.95 (for example manual clamp, doc list formatting, redundant closures, and related existing warnings outside this patch).
- [ ] Manually exercised in the packaged GUI.