### PR TITLE
feat: add slash-command popup to chat + terminal tabs

### DIFF
--- a/crates/core/src/gui.rs
+++ b/crates/core/src/gui.rs
@@ -1086,6 +1086,60 @@ pub fn run_gui() {
                         let _ = responder.send(text);
                     }
                 }
+                "slash_commands_list" => {
+                    // Build the autocomplete catalogue for the chat-tab
+                    // `/` popup. Three sources:
+                    //   1. built-in commands (hard-coded in repl.rs so
+                    //      the parser and the popup stay in lock-step),
+                    //   2. user commands from .claude/commands/ etc.,
+                    //   3. installed skills (also reachable as /<name>).
+                    let mut entries: Vec<serde_json::Value> = Vec::new();
+                    for c in crate::repl::built_in_commands() {
+                        entries.push(serde_json::json!({
+                            "name": c.name,
+                            "description": c.description,
+                            "category": c.category,
+                            "usage": c.usage,
+                            "source": "builtin",
+                        }));
+                    }
+                    let user_cmds = crate::commands::CommandStore::discover();
+                    let mut user_names: Vec<&str> = user_cmds.commands.keys()
+                        .map(String::as_str)
+                        .collect();
+                    user_names.sort();
+                    for name in user_names {
+                        if let Some(cmd) = user_cmds.get(name) {
+                            entries.push(serde_json::json!({
+                                "name": cmd.name,
+                                "description": cmd.description,
+                                "category": "Custom",
+                                "usage": "",
+                                "source": "user",
+                            }));
+                        }
+                    }
+                    let skill_store = crate::skills::SkillStore::discover();
+                    let mut skill_entries: Vec<&crate::skills::SkillDef> =
+                        skill_store.skills.values().collect();
+                    skill_entries.sort_by(|a, b| a.name.cmp(&b.name));
+                    for s in skill_entries {
+                        entries.push(serde_json::json!({
+                            "name": s.name,
+                            "description": s.description,
+                            "category": "Skills",
+                            "usage": "",
+                            "source": "skill",
+                        }));
+                    }
+                    let payload = serde_json::json!({
+                        "type": "slash_commands",
+                        "commands": entries,
+                    });
+                    let _ = proxy_for_ipc.send_event(UserEvent::SessionLoaded(
+                        payload.to_string(),
+                    ));
+                }
                 "get_cwd" => {
                     let cwd = std::env::current_dir()
                         .map(|p| p.to_string_lossy().to_string())

--- a/crates/core/src/repl.rs
+++ b/crates/core/src/repl.rs
@@ -482,6 +482,68 @@ fn parse_kms_subcommand(args: &str) -> SlashCommand {
     }
 }
 
+/// One built-in slash command, surfaced to the GUI's `/` popup so it can
+/// render an autocomplete list grouped by `category`.
+///
+/// Keep this list in lock-step with the `parse_slash` arms in this file
+/// and the dispatch arms in `shell_dispatch.rs`. Help text is the
+/// single-line summary shown next to the name in the popup; longer
+/// usage syntax (e.g. flags, sub-commands) goes in `usage` so the
+/// popup can render it as dim trailing text.
+pub struct BuiltInCommand {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub category: &'static str,
+    /// Optional argument hint, e.g. `"NAME"` for `/model NAME`. Empty
+    /// when the command takes no arguments.
+    pub usage: &'static str,
+}
+
+pub fn built_in_commands() -> &'static [BuiltInCommand] {
+    &[
+        // Session
+        BuiltInCommand { name: "clear",    description: "Clear conversation history",                 category: "Session", usage: "" },
+        BuiltInCommand { name: "compact",  description: "Compact history (drop oldest, keep recent)", category: "Session", usage: "" },
+        BuiltInCommand { name: "fork",     description: "Save + start a new session seeded with a summary", category: "Session", usage: "" },
+        BuiltInCommand { name: "save",     description: "Force-save the current session",             category: "Session", usage: "" },
+        BuiltInCommand { name: "load",     description: "Load a saved session by id or name",         category: "Session", usage: "ID|NAME" },
+        BuiltInCommand { name: "sessions", description: "List saved sessions",                        category: "Session", usage: "" },
+        BuiltInCommand { name: "rename",   description: "Rename the current session",                 category: "Session", usage: "NAME" },
+        BuiltInCommand { name: "history",  description: "Print message-history summary",              category: "Session", usage: "" },
+
+        // Model
+        BuiltInCommand { name: "model",     description: "Show or switch the current model",          category: "Model", usage: "[NAME]" },
+        BuiltInCommand { name: "models",    description: "List models from the current provider",     category: "Model", usage: "" },
+        BuiltInCommand { name: "provider",  description: "Switch provider to its default model",      category: "Model", usage: "NAME" },
+        BuiltInCommand { name: "providers", description: "List all supported providers",              category: "Model", usage: "" },
+        BuiltInCommand { name: "thinking",  description: "Set extended-thinking token budget",        category: "Model", usage: "BUDGET" },
+        BuiltInCommand { name: "permissions", description: "Show or set the permission mode",         category: "Model", usage: "[auto|ask]" },
+
+        // Context / memory / knowledge
+        BuiltInCommand { name: "context",  description: "Show context-window usage breakdown",        category: "Context", usage: "" },
+        BuiltInCommand { name: "memory",   description: "List memory entries",                        category: "Context", usage: "" },
+        BuiltInCommand { name: "kms",      description: "List knowledge bases",                       category: "Context", usage: "" },
+
+        // Skills, plugins, MCP
+        BuiltInCommand { name: "skills",   description: "List installed skills",                      category: "Extensions", usage: "" },
+        BuiltInCommand { name: "plugins",  description: "List installed plugins",                     category: "Extensions", usage: "" },
+        BuiltInCommand { name: "mcp",      description: "List active MCP servers and their tools",    category: "Extensions", usage: "" },
+
+        // Team
+        BuiltInCommand { name: "team",     description: "Show team agent status",                     category: "Team", usage: "" },
+        BuiltInCommand { name: "tasks",    description: "List current tasks/todos",                   category: "Team", usage: "" },
+
+        // System
+        BuiltInCommand { name: "help",     description: "Show this help",                             category: "System", usage: "" },
+        BuiltInCommand { name: "version",  description: "Show version",                               category: "System", usage: "" },
+        BuiltInCommand { name: "cwd",      description: "Show current working directory",             category: "System", usage: "" },
+        BuiltInCommand { name: "usage",    description: "Show token usage by provider and model",     category: "System", usage: "" },
+        BuiltInCommand { name: "doctor",   description: "Run diagnostics",                            category: "System", usage: "" },
+        BuiltInCommand { name: "config",   description: "Set a config value (session-only)",          category: "System", usage: "key=value" },
+        BuiltInCommand { name: "quit",     description: "Exit",                                       category: "System", usage: "" },
+    ]
+}
+
 pub fn render_help() -> &'static str {
     "Slash commands:\n  \
      /help             Show this help\n  \

--- a/crates/core/src/repl.rs
+++ b/crates/core/src/repl.rs
@@ -499,6 +499,10 @@ pub struct BuiltInCommand {
     pub usage: &'static str,
 }
 
+// Hand-aligned struct-literal table — keeping the columns reads well at a
+// glance and rustfmt's exploded form (~6 lines per row) bloats the function
+// to >180 lines for the same content. Skip for the table only.
+#[rustfmt::skip]
 pub fn built_in_commands() -> &'static [BuiltInCommand] {
     &[
         // Session

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -7,6 +7,11 @@ import { send, subscribe } from "../hooks/useIPC";
 import { useTheme } from "../hooks/useTheme";
 import logoDark from "../assets/thClaws-logo-dark.png";
 import logoLight from "../assets/thClaws-logo-light.png";
+import {
+  SlashCommandPopup,
+  filterCommands,
+  type SlashCommandInfo,
+} from "./SlashCommandPopup";
 
 type ChatMessage = {
   role: "user" | "assistant" | "tool" | "system";
@@ -69,10 +74,24 @@ export function ChatView() {
     null,
   );
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
+  const [slashCommands, setSlashCommands] = useState<SlashCommandInfo[]>([]);
+  const [slashIndex, setSlashIndex] = useState(0);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const copiedTimerRef = useRef<number | null>(null);
   const errorTimerRef = useRef<number | null>(null);
   const { resolved: themeMode } = useTheme();
+
+  // Show the slash popup whenever the input begins with `/` and the
+  // user isn't mid-prompt for an `ask_user_question`. Hidden during a
+  // streaming turn — slash commands fire instantly so there's nothing
+  // useful to autocomplete while the model is still talking.
+  const slashOpen =
+    !askPrompt && !streaming && input.startsWith("/");
+  const slashQuery = slashOpen ? input.slice(1).split(/\s/)[0] : "";
+  const slashFiltered = slashOpen
+    ? filterCommands(slashCommands, slashQuery)
+    : [];
 
   const showAttachmentError = (msg: string) => {
     setAttachmentError(msg);
@@ -255,6 +274,11 @@ export function ChatView() {
           setStreaming(false);
           setAskPrompt(null);
           break;
+        case "slash_commands":
+          if (Array.isArray(msg.commands)) {
+            setSlashCommands(msg.commands as SlashCommandInfo[]);
+          }
+          break;
         case "chat_history_replaced":
           if (msg.messages && Array.isArray(msg.messages)) {
             setMessages(
@@ -290,8 +314,21 @@ export function ChatView() {
           break;
       }
     });
+    // Ask the backend for the slash command catalogue once on mount.
+    // The backend returns a `slash_commands` event the subscriber above
+    // catches; new user commands / installed skills will only be picked
+    // up on next mount, which matches the rest of the GUI's
+    // discover-once-per-session behavior.
+    send({ type: "slash_commands_list" });
     return unsub;
   }, []);
+
+  useEffect(() => {
+    // Reset the highlighted item whenever the filtered list changes
+    // shape — keeping a stale index past the end of the new list would
+    // either render off-screen or wrap unexpectedly.
+    setSlashIndex(0);
+  }, [slashQuery, slashOpen]);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -349,6 +386,47 @@ export function ChatView() {
         data: a.data,
       })),
     });
+  };
+
+  const acceptSlashCommand = (cmd: SlashCommandInfo) => {
+    // Commands with required args (usage non-empty and not optional)
+    // get the slash + name + trailing space inserted so the user can
+    // immediately type the argument. Zero-arg commands fire on enter.
+    const needsArg = cmd.usage && !cmd.usage.startsWith("[");
+    setInput(`/${cmd.name}${needsArg ? " " : ""}`);
+    setSlashIndex(0);
+    inputRef.current?.focus();
+  };
+
+  const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!slashOpen || slashFiltered.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSlashIndex((i) => (i + 1) % slashFiltered.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSlashIndex(
+        (i) => (i - 1 + slashFiltered.length) % slashFiltered.length,
+      );
+    } else if (e.key === "Tab") {
+      e.preventDefault();
+      const cmd = slashFiltered[slashIndex];
+      if (cmd) acceptSlashCommand(cmd);
+    } else if (e.key === "Enter") {
+      // Only intercept Enter when the user is still composing the
+      // command name itself ("/cl" → fill in "/clear"). Once they've
+      // typed past the name into args ("/model gpt-5"), Enter should
+      // submit normally so they don't have to dismiss the popup first.
+      const composingName = !input.slice(1).includes(" ");
+      if (composingName) {
+        e.preventDefault();
+        const cmd = slashFiltered[slashIndex];
+        if (cmd) acceptSlashCommand(cmd);
+      }
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setInput("");
+    }
   };
 
   const awaitingUserAnswer = askPrompt !== null;
@@ -564,11 +642,22 @@ export function ChatView() {
             ))}
           </div>
         )}
+        {slashOpen && slashFiltered.length > 0 && (
+          <SlashCommandPopup
+            query={slashQuery}
+            commands={slashCommands}
+            selectedIndex={slashIndex}
+            onHoverIndex={setSlashIndex}
+            onSelect={acceptSlashCommand}
+          />
+        )}
         <div className="flex gap-2">
           <input
+            ref={inputRef}
             type="text"
             value={input}
             onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleInputKeyDown}
             onPaste={onPaste}
             placeholder={inputPlaceholder}
             disabled={inputDisabled}

--- a/frontend/src/components/SlashCommandPopup.tsx
+++ b/frontend/src/components/SlashCommandPopup.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useMemo, useRef } from "react";
+
+export type SlashCommandInfo = {
+  name: string;
+  description: string;
+  category: string;
+  usage: string;
+  source: "builtin" | "user" | "skill";
+};
+
+type Props = {
+  query: string;
+  commands: SlashCommandInfo[];
+  selectedIndex: number;
+  onHoverIndex: (i: number) => void;
+  onSelect: (cmd: SlashCommandInfo) => void;
+};
+
+/// Popup shown above the chat input when the user types a leading "/".
+///
+/// Filtering is prefix-match on the command name (case-insensitive).
+/// Items are grouped by `category` in source order — the parent owns
+/// `selectedIndex` so arrow keys/Enter can be handled in ChatView's
+/// `onKeyDown` without bubbling synthetic events between components.
+export function SlashCommandPopup({
+  query,
+  commands,
+  selectedIndex,
+  onHoverIndex,
+  onSelect,
+}: Props) {
+  const filtered = useMemo(() => filterCommands(commands, query), [commands, query]);
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  useEffect(() => {
+    const el = itemRefs.current[selectedIndex];
+    if (el) el.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  if (filtered.length === 0) return null;
+
+  const grouped = groupByCategory(filtered);
+  let runningIndex = -1;
+
+  return (
+    <div
+      className="rounded-lg border shadow-xl overflow-y-auto"
+      style={{
+        background: "var(--bg-secondary)",
+        borderColor: "var(--border)",
+        maxHeight: 320,
+      }}
+      onMouseDown={(e) => e.preventDefault()}
+    >
+      {grouped.map(([category, items]) => (
+        <div key={category}>
+          <div
+            className="px-3 pt-2 pb-1 text-[10px] uppercase tracking-wider"
+            style={{ color: "var(--text-secondary)" }}
+          >
+            {category}
+          </div>
+          {items.map((cmd) => {
+            runningIndex += 1;
+            const idx = runningIndex;
+            const active = idx === selectedIndex;
+            return (
+              <button
+                key={`${cmd.source}:${cmd.name}`}
+                ref={(el) => {
+                  itemRefs.current[idx] = el;
+                }}
+                type="button"
+                onMouseEnter={() => onHoverIndex(idx)}
+                onClick={() => onSelect(cmd)}
+                className="w-full text-left px-3 py-1.5 flex items-baseline gap-2 text-sm"
+                style={{
+                  background: active ? "var(--accent)" : "transparent",
+                  color: active ? "var(--accent-fg)" : "var(--text-primary)",
+                  cursor: "pointer",
+                  border: "none",
+                }}
+              >
+                <span className="font-mono">/{cmd.name}</span>
+                {cmd.usage && (
+                  <span
+                    className="font-mono text-xs"
+                    style={{
+                      color: active ? "var(--accent-fg)" : "var(--text-secondary)",
+                      opacity: 0.8,
+                    }}
+                  >
+                    {cmd.usage}
+                  </span>
+                )}
+                {cmd.description && (
+                  <span
+                    className="text-xs truncate ml-auto"
+                    style={{
+                      color: active ? "var(--accent-fg)" : "var(--text-secondary)",
+                      opacity: 0.85,
+                    }}
+                  >
+                    {cmd.description}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/// Filter commands by case-insensitive prefix match against `query`.
+/// `query` is the text after the leading slash (may be empty when the
+/// user has typed only "/").
+export function filterCommands(
+  commands: SlashCommandInfo[],
+  query: string,
+): SlashCommandInfo[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return commands;
+  return commands.filter((c) => c.name.toLowerCase().startsWith(q));
+}
+
+function groupByCategory(
+  items: SlashCommandInfo[],
+): Array<[string, SlashCommandInfo[]]> {
+  const map = new Map<string, SlashCommandInfo[]>();
+  for (const item of items) {
+    const list = map.get(item.category);
+    if (list) list.push(item);
+    else map.set(item.category, [item]);
+  }
+  return Array.from(map.entries());
+}

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -1,10 +1,29 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
 import { send, subscribe } from "../hooks/useIPC";
 import { useTheme } from "../hooks/useTheme";
+import {
+  SlashCommandPopup,
+  filterCommands,
+  type SlashCommandInfo,
+} from "./SlashCommandPopup";
 import bannerText from "../../../banner.txt?raw";
+
+type SlashView = {
+  open: boolean;
+  query: string;
+  index: number;
+  filtered: SlashCommandInfo[];
+};
+
+const SLASH_VIEW_CLOSED: SlashView = {
+  open: false,
+  query: "",
+  index: 0,
+  filtered: [],
+};
 
 // xterm needs CRLF; the shared banner file uses plain LF so the Rust REPL
 // can println! it unchanged.
@@ -51,6 +70,31 @@ export function TerminalView({ active }: Props) {
   const { resolved: themeMode } = useTheme();
   const themeModeRef = useRef(themeMode);
   useEffect(() => { themeModeRef.current = themeMode; }, [themeMode]);
+
+  // Slash-command catalogue mirrored from the backend, plus the live
+  // popup state. The xterm closure keeps the line buffer locally; we
+  // bridge to React via refs so `attachCustomKeyEventHandler` and
+  // `onData` can read/update the popup view without re-mounting xterm.
+  const [slashCommands, setSlashCommands] = useState<SlashCommandInfo[]>([]);
+  const slashCommandsRef = useRef<SlashCommandInfo[]>([]);
+  const [slashView, setSlashView] = useState<SlashView>(SLASH_VIEW_CLOSED);
+  const slashViewRef = useRef(slashView);
+  useEffect(() => { slashViewRef.current = slashView; }, [slashView]);
+  // Bridge React clicks back into the xterm closure where lineBuffer
+  // lives. Set inside the mount effect; called from the popup's onSelect.
+  const acceptSlashRef = useRef<(cmd: SlashCommandInfo) => void>(() => {});
+
+  useEffect(() => {
+    send({ type: "slash_commands_list" });
+    const unsub = subscribe((msg) => {
+      if (msg.type === "slash_commands" && Array.isArray(msg.commands)) {
+        const list = msg.commands as SlashCommandInfo[];
+        slashCommandsRef.current = list;
+        setSlashCommands(list);
+      }
+    });
+    return unsub;
+  }, []);
 
   useEffect(() => {
     if (!ref.current || termRef.current) return;
@@ -99,7 +143,41 @@ export function TerminalView({ active }: Props) {
       writePrompt();
       lineBuffer = next;
       if (next.length > 0) term.write(next);
+      recomputeSlash();
     };
+
+    // Recompute the slash-popup state from the current `lineBuffer`.
+    // The popup is open iff the buffer starts with `/` AND the user
+    // hasn't typed a space yet (once we hit "/model gpt-5", we're past
+    // composing the name). Index is preserved across keystrokes so the
+    // user's selection doesn't jump back to the top on every char.
+    const recomputeSlash = () => {
+      const open = lineBuffer.startsWith("/") && !lineBuffer.includes(" ");
+      if (!open) {
+        if (slashViewRef.current.open) setSlashView(SLASH_VIEW_CLOSED);
+        return;
+      }
+      const query = lineBuffer.slice(1);
+      const filtered = filterCommands(slashCommandsRef.current, query);
+      const prev = slashViewRef.current;
+      let index = prev.open && prev.query === query ? prev.index : 0;
+      if (index >= filtered.length) index = 0;
+      setSlashView({ open: true, query, index, filtered });
+    };
+
+    // Accept a command into the line buffer + visible terminal. Args-
+    // required commands (e.g. /model NAME) get a trailing space so the
+    // user can keep typing; zero-arg commands stop at the name.
+    const acceptSlashCommand = (cmd: SlashCommandInfo) => {
+      const needsArg = cmd.usage && !cmd.usage.startsWith("[");
+      const next = `/${cmd.name}${needsArg ? " " : ""}`;
+      term.write("\x1b[2K\r");
+      writePrompt();
+      lineBuffer = next;
+      term.write(next);
+      recomputeSlash();
+    };
+    acceptSlashRef.current = acceptSlashCommand;
 
     // Record a successfully-submitted prompt in the recall ring.
     // Skips exact duplicates of the most recent entry (Ctrl+↑ in bash
@@ -140,6 +218,52 @@ export function TerminalView({ active }: Props) {
       const isMac = navigator.platform.startsWith("Mac");
       const mod = isMac ? e.metaKey : e.ctrlKey && e.shiftKey;
 
+      // Slash-command popup: when open, intercept navigation/accept/
+      // dismiss keys so xterm doesn't also process them as input. Only
+      // fires on keydown and only when no modifiers are held — Cmd+↑
+      // / Ctrl+Tab / etc. should pass through unchanged.
+      if (
+        e.type === "keydown" &&
+        !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey
+      ) {
+        const sv = slashViewRef.current;
+        if (sv.open && sv.filtered.length > 0) {
+          if (e.key === "ArrowDown") {
+            const next = (sv.index + 1) % sv.filtered.length;
+            setSlashView({ ...sv, index: next });
+            return false;
+          }
+          if (e.key === "ArrowUp") {
+            const next = (sv.index - 1 + sv.filtered.length) % sv.filtered.length;
+            setSlashView({ ...sv, index: next });
+            return false;
+          }
+          if (e.key === "Tab") {
+            const cmd = sv.filtered[sv.index];
+            if (cmd) acceptSlashCommand(cmd);
+            return false;
+          }
+          if (e.key === "Escape") {
+            term.write("\x1b[2K\r");
+            writePrompt();
+            lineBuffer = "";
+            recomputeSlash();
+            return false;
+          }
+          if (e.key === "Enter") {
+            // While the user is still composing the name (no space yet),
+            // Enter accepts the highlighted item — same UX as the chat
+            // tab. Once they've typed past the name into args, Enter
+            // falls through and the existing onData path submits.
+            if (!lineBuffer.includes(" ")) {
+              const cmd = sv.filtered[sv.index];
+              if (cmd) acceptSlashCommand(cmd);
+              return false;
+            }
+          }
+        }
+      }
+
       // Plain Ctrl+C:
       //  - non-empty input line → clear the line (same as bash)
       //  - empty line → request abort of the in-flight turn via the
@@ -154,6 +278,7 @@ export function TerminalView({ active }: Props) {
           term.write("\x1b[2K\r");
           lineBuffer = "";
           writePrompt(); // also flips promptShowing back on
+          recomputeSlash();
         } else {
           send({ type: "shell_cancel" });
         }
@@ -232,6 +357,7 @@ export function TerminalView({ active }: Props) {
                 // Enter.
                 lineBuffer += text;
                 term.write(text);
+                recomputeSlash();
               }
             }
           }
@@ -306,6 +432,7 @@ export function TerminalView({ active }: Props) {
 
       // xterm hands us each keystroke as a string; classify and either
       // mutate the buffer + echo, or submit on Enter.
+      let bufferMutated = false;
       for (const ch of data) {
         if (ch === "\r" || ch === "\n") {
           if (lineBuffer.trim().length > 0) {
@@ -322,18 +449,22 @@ export function TerminalView({ active }: Props) {
             writePrompt();
           }
           lineBuffer = "";
+          bufferMutated = true;
         } else if (ch === "\x7f" || ch === "\b") {
           if (lineBuffer.length > 0) {
             lineBuffer = lineBuffer.slice(0, -1);
             // Move cursor back, overwrite with space, move back again.
             term.write("\b \b");
+            bufferMutated = true;
           }
         } else if (ch >= " " && ch !== "\x7f") {
           lineBuffer += ch;
           term.write(ch);
+          bufferMutated = true;
         }
         // Other control bytes are dropped.
       }
+      if (bufferMutated) recomputeSlash();
     });
 
     // Note: no resize IPC — the shared session doesn't care about
@@ -437,9 +568,26 @@ export function TerminalView({ active }: Props) {
 
   return (
     <div
-      ref={ref}
-      className="h-full w-full p-1.5"
+      className="relative h-full w-full"
       style={{ background: "var(--terminal-bg)" }}
-    />
+    >
+      <div ref={ref} className="h-full w-full p-1.5" />
+      {slashView.open && slashView.filtered.length > 0 && (
+        <div
+          className="absolute left-3 right-3 bottom-3"
+          style={{ pointerEvents: "auto" }}
+        >
+          <SlashCommandPopup
+            query={slashView.query}
+            commands={slashCommands}
+            selectedIndex={slashView.index}
+            onHoverIndex={(i) =>
+              setSlashView((prev) => ({ ...prev, index: i }))
+            }
+            onSelect={(cmd) => acceptSlashRef.current(cmd)}
+          />
+        </div>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
Surfaces an autocomplete menu when the user types `/` in either tab, backed by a new `slash_commands_list` IPC that aggregates built-in commands, user `.claude/commands/` entries, and installed skills.

- repl.rs: `built_in_commands()` returns the popup catalogue (name, description, category, usage) — kept next to `render_help` so the parser and the UI stay in sync.
- gui.rs: new IPC handler responds with grouped command metadata.
- SlashCommandPopup.tsx: shared popup component with prefix-match filter and category headers.
- ChatView / TerminalView: keystroke handling for ↑↓ Tab Enter Esc, with Enter falling through to submit once args are being typed.

## Summary

Briefly describe what this PR does.

## Motivation

Why is this change needed? Link the issue it closes (e.g. `Closes #123`).

## Changes

- ...
- ...

## Test plan

How did you verify this works?

- [ ] `cargo test --features gui` passes locally
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --features gui -- -D warnings` passes
- [ ] Frontend type-check passes (`cd frontend && pnpm tsc --noEmit`) — if frontend touched
- [ ] Manually exercised the feature — steps:
  1. ...
  2. ...

## Screenshots / recordings

For GUI / CLI UX changes, include a before / after screenshot or short recording.

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if behavior changes (README / CHANGELOG / in-repo docs)
- [ ] No new compiler warnings introduced
- [ ] PR scope is focused — no unrelated changes
- [ ] Commits follow project style (concise, imperative, optional `feat/fix/docs/...` prefix)
