### PR TITLE
feat: add Azure AI Foundry provider for Claude

### DIFF
--- a/crates/core/src/model_catalogue.rs
+++ b/crates/core/src/model_catalogue.rs
@@ -308,6 +308,7 @@ pub fn provider_kind_name(k: crate::providers::ProviderKind) -> &'static str {
         ProviderKind::AgenticPress => "agentic-press",
         ProviderKind::ZAi => "zai",
         ProviderKind::LMStudio => "lmstudio",
+        ProviderKind::AzureAIFoundry => "azure",
     }
 }
 

--- a/crates/core/src/providers/anthropic.rs
+++ b/crates/core/src/providers/anthropic.rs
@@ -23,6 +23,9 @@ pub struct AnthropicProvider {
     client: Client,
     api_key: String,
     base_url: String,
+    /// Optional override for the auth header name. `None` → `x-api-key`
+    /// (the standard Anthropic header, also accepted by Azure AI Foundry).
+    api_key_header: Option<String>,
 }
 
 impl AnthropicProvider {
@@ -31,6 +34,7 @@ impl AnthropicProvider {
             client: Client::new(),
             api_key: api_key.into(),
             base_url: DEFAULT_API_URL.to_string(),
+            api_key_header: None,
         }
     }
 
@@ -38,6 +42,15 @@ impl AnthropicProvider {
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = url.into();
         self
+    }
+
+    pub fn with_api_key_header(mut self, name: impl Into<String>) -> Self {
+        self.api_key_header = Some(name.into());
+        self
+    }
+
+    fn auth_header_name(&self) -> &str {
+        self.api_key_header.as_deref().unwrap_or("x-api-key")
     }
 
     fn build_body(req: &StreamRequest) -> Value {
@@ -57,9 +70,12 @@ impl AnthropicProvider {
             })
             .collect();
 
-        // Strip provider prefixes (oa/) so the model name matches what
-        // Ollama or other backends expect.
-        let model = req.model.strip_prefix("oa/").unwrap_or(&req.model);
+        // Strip provider prefixes so the model name matches what the backend expects.
+        let model = req
+            .model
+            .strip_prefix("oa/")
+            .or_else(|| req.model.strip_prefix("azure/"))
+            .unwrap_or(&req.model);
 
         let mut body = json!({
             "model": model,
@@ -115,7 +131,7 @@ impl Provider for AnthropicProvider {
         let resp = self
             .client
             .get(&models_url)
-            .header("x-api-key", &self.api_key)
+            .header(self.auth_header_name(), &self.api_key)
             .header("anthropic-version", API_VERSION)
             .send()
             .await
@@ -157,7 +173,7 @@ impl Provider for AnthropicProvider {
         let resp = self
             .client
             .post(&self.base_url)
-            .header("x-api-key", &self.api_key)
+            .header(self.auth_header_name(), &self.api_key)
             .header("anthropic-version", API_VERSION)
             .header("content-type", "application/json")
             .json(&body)

--- a/crates/core/src/providers/mod.rs
+++ b/crates/core/src/providers/mod.rs
@@ -33,6 +33,7 @@ pub enum ProviderKind {
     DashScope,
     ZAi,
     LMStudio,
+    AzureAIFoundry,
 }
 
 impl ProviderKind {
@@ -49,6 +50,7 @@ impl ProviderKind {
         Self::DashScope,
         Self::ZAi,
         Self::LMStudio,
+        Self::AzureAIFoundry,
     ];
 
     pub fn name(&self) -> &'static str {
@@ -65,6 +67,7 @@ impl ProviderKind {
             Self::DashScope => "dashscope",
             Self::ZAi => "zai",
             Self::LMStudio => "lmstudio",
+            Self::AzureAIFoundry => "azure",
         }
     }
 
@@ -87,6 +90,11 @@ impl ProviderKind {
             // will populate the GUI dropdown with whatever's actually
             // loaded.
             Self::LMStudio => "lmstudio/llama-3.2-3b-instruct",
+            // Azure AI Foundry deployments are user-specific (each subscription
+            // names its own deployments), so there's no sensible default. The
+            // placeholder routes to the right provider but forces the user to
+            // override with `/model azure/<your-deployment>`.
+            Self::AzureAIFoundry => "azure/<deployment>",
         }
     }
 
@@ -102,6 +110,7 @@ impl ProviderKind {
             Self::OllamaAnthropic => Some("OLLAMA_BASE_URL"),
             Self::ZAi => Some("ZAI_BASE_URL"),
             Self::LMStudio => Some("LMSTUDIO_BASE_URL"),
+            Self::AzureAIFoundry => Some("AZURE_AI_FOUNDRY_ENDPOINT"),
             _ => None,
         }
     }
@@ -112,7 +121,10 @@ impl ProviderKind {
     /// backends like Ollama and LMStudio are surfaced for editing. The env
     /// var still overrides at startup for power users who need it.
     pub fn endpoint_user_configurable(&self) -> bool {
-        matches!(self, Self::Ollama | Self::OllamaAnthropic | Self::LMStudio,)
+        matches!(
+            self,
+            Self::Ollama | Self::OllamaAnthropic | Self::LMStudio | Self::AzureAIFoundry,
+        )
     }
 
     /// Default base URL shown as a placeholder in the Settings UI when the
@@ -133,6 +145,7 @@ impl ProviderKind {
             // Default port 1234; users routinely change it, hence the
             // editable Settings field above.
             Self::LMStudio => Some("http://localhost:1234/v1"),
+            Self::AzureAIFoundry => Some("https://{resource}.services.ai.azure.com"),
             _ => None,
         }
     }
@@ -152,6 +165,7 @@ impl ProviderKind {
             Self::DashScope => Some("DASHSCOPE_API_KEY"),
             Self::ZAi => Some("ZAI_API_KEY"),
             Self::LMStudio => None, // Local runtime, no auth.
+            Self::AzureAIFoundry => Some("AZURE_AI_FOUNDRY_API_KEY"),
         }
     }
 
@@ -226,7 +240,8 @@ impl ProviderKind {
             | Self::OllamaAnthropic
             | Self::DashScope
             | Self::ZAi
-            | Self::LMStudio => None,
+            | Self::LMStudio
+            | Self::AzureAIFoundry => None,
         }
     }
 
@@ -275,6 +290,8 @@ impl ProviderKind {
             Some(Self::OllamaAnthropic)
         } else if model.starts_with("ollama/") {
             Some(Self::Ollama)
+        } else if model.starts_with("azure/") {
+            Some(Self::AzureAIFoundry)
         } else {
             None
         }

--- a/crates/core/src/providers/openai.rs
+++ b/crates/core/src/providers/openai.rs
@@ -36,6 +36,14 @@ pub struct OpenAIProvider {
     /// `gemma4-12b`) where the prefix exists only to route `detect()` on
     /// our side.
     strip_model_prefix: Option<String>,
+    /// Override the auth header name. `None` → `Authorization: Bearer {key}`.
+    /// Azure AI Foundry uses `api-key: {key}` instead.
+    api_key_header: Option<String>,
+    /// Explicit URL for GET /models. When `None` the URL is derived from
+    /// `base_url` by replacing `/chat/completions` with `/models`.
+    /// Azure's models path differs from the completions path, so it needs
+    /// an explicit override.
+    list_models_url: Option<String>,
 }
 
 impl OpenAIProvider {
@@ -45,6 +53,8 @@ impl OpenAIProvider {
             api_key: api_key.into(),
             base_url: DEFAULT_API_URL.to_string(),
             strip_model_prefix: None,
+            api_key_header: None,
+            list_models_url: None,
         }
     }
 
@@ -56,6 +66,27 @@ impl OpenAIProvider {
     pub fn with_strip_model_prefix(mut self, prefix: impl Into<String>) -> Self {
         self.strip_model_prefix = Some(prefix.into());
         self
+    }
+
+    pub fn with_api_key_header(mut self, name: impl Into<String>) -> Self {
+        self.api_key_header = Some(name.into());
+        self
+    }
+
+    pub fn with_list_models_url(mut self, url: impl Into<String>) -> Self {
+        self.list_models_url = Some(url.into());
+        self
+    }
+
+    fn auth_header_name(&self) -> &str {
+        self.api_key_header.as_deref().unwrap_or("authorization")
+    }
+
+    fn auth_header_value(&self) -> String {
+        match &self.api_key_header {
+            Some(_) => self.api_key.clone(),
+            None => format!("Bearer {}", self.api_key),
+        }
     }
 
     /// Convert canonical `Message`s → OpenAI chat/completions messages array.
@@ -300,17 +331,18 @@ fn extract_images(content: &ToolResultContent) -> Vec<(String, String)> {
 #[async_trait]
 impl Provider for OpenAIProvider {
     async fn list_models(&self) -> Result<Vec<ModelInfo>> {
-        // /v1/chat/completions → /v1/models
-        let models_url = self
-            .base_url
-            .rsplit_once("/chat/completions")
-            .map(|(base, _)| format!("{base}/models"))
-            .unwrap_or_else(|| format!("{}/models", self.base_url.trim_end_matches('/')));
+        let models_url = self.list_models_url.clone().unwrap_or_else(|| {
+            // Derive from base_url: /v1/chat/completions → /v1/models
+            self.base_url
+                .rsplit_once("/chat/completions")
+                .map(|(base, _)| format!("{base}/models"))
+                .unwrap_or_else(|| format!("{}/models", self.base_url.trim_end_matches('/')))
+        });
 
         let resp = self
             .client
             .get(&models_url)
-            .header("authorization", format!("Bearer {}", self.api_key))
+            .header(self.auth_header_name(), self.auth_header_value())
             .send()
             .await
             .map_err(|e| Error::Provider(format!("http: {e}")))?;
@@ -365,7 +397,7 @@ impl Provider for OpenAIProvider {
         let resp = self
             .client
             .post(&self.base_url)
-            .header("authorization", format!("Bearer {}", self.api_key))
+            .header(self.auth_header_name(), self.auth_header_value())
             .header("content-type", "application/json")
             .json(&body)
             .send()

--- a/crates/core/src/repl.rs
+++ b/crates/core/src/repl.rs
@@ -659,6 +659,19 @@ pub fn build_provider(config: &AppConfig) -> Result<Arc<dyn Provider>> {
                     .with_strip_model_prefix("zai/"),
             ))
         }
+        ProviderKind::AzureAIFoundry => {
+            let endpoint = std::env::var("AZURE_AI_FOUNDRY_ENDPOINT").map_err(|_| {
+                Error::Config(
+                    "AZURE_AI_FOUNDRY_ENDPOINT not set — add it in Settings or export the env var"
+                        .into(),
+                )
+            })?;
+            let base = endpoint.trim_end_matches('/');
+            let messages_url = format!("{base}/anthropic/v1/messages");
+            Ok(Arc::new(
+                AnthropicProvider::new(api_key).with_base_url(messages_url),
+            ))
+        }
         ProviderKind::Ollama
         | ProviderKind::OllamaAnthropic
         | ProviderKind::LMStudio

--- a/crates/core/src/secrets.rs
+++ b/crates/core/src/secrets.rs
@@ -98,6 +98,7 @@ const MANAGED: &[ProviderKind] = &[
     ProviderKind::Gemini,
     ProviderKind::DashScope,
     ProviderKind::ZAi,
+    ProviderKind::AzureAIFoundry,
 ];
 
 fn entry(provider: &str) -> Result<keyring::Entry> {

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -41,6 +41,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   dashscope: "Alibaba DashScope",
   ollama: "Ollama",
   "ollama-anthropic": "Ollama (Anthropic-compatible)",
+  azure: "Azure AI Foundry",
 };
 
 export function SettingsModal({ onClose }: { onClose: () => void }) {


### PR DESCRIPTION
Azure AI Foundry exposes Claude deployments via an Anthropic-native
endpoint at `/anthropic/v1/messages` using the `x-api-key` header.
Add `ProviderKind::AzureAIFoundry` that reuses `AnthropicProvider`
with a custom base URL pointing at the resource's Foundry endpoint.

- AnthropicProvider: optional `api_key_header` override and strip
  `azure/` prefix from the model id alongside `oa/`
- OpenAIProvider: `api_key_header` and `list_models_url` builders
  for any future Azure OpenAI use
- secrets: register under MANAGED so the API key is keychain-backed
- frontend SettingsModal: label "Azure AI Foundry"

Each Azure subscription names its own deployments, so `default_model`
returns the placeholder `azure/<deployment>` rather than a hard-coded
guess that would just route a wrong model id to the Anthropic
endpoint. Users set their real deployment via `/model azure/<name>`
once `AZURE_AI_FOUNDRY_ENDPOINT` and `AZURE_AI_FOUNDRY_API_KEY` are set.