### PR TITLE
fix(gemini): Use Gemini 2.5 Flash by default

### DIFF
--- a/crates/core/src/providers/mod.rs
+++ b/crates/core/src/providers/mod.rs
@@ -76,7 +76,7 @@ impl ProviderKind {
             Self::OpenAI => "gpt-4o",
             Self::OpenAIResponses => "codex/gpt-5.2-codex",
             Self::OpenRouter => "openrouter/anthropic/claude-sonnet-4-6",
-            Self::Gemini => "gemini-2.0-flash",
+            Self::Gemini => "gemini-2.5-flash",
             Self::Ollama => "ollama/llama3.2",
             Self::OllamaAnthropic => "oa/qwen3-coder",
             Self::DashScope => "qwen-max",

--- a/crates/core/src/repl.rs
+++ b/crates/core/src/repl.rs
@@ -1910,7 +1910,7 @@ pub async fn run_repl(mut config: AppConfig) -> Result<()> {
                         continue;
                     }
                     // Resolve short aliases ("sonnet" → "claude-sonnet-4-6",
-                    // "flash" → "gemini-2.0-flash", etc.) to the canonical
+                    // "flash" → "gemini-2.5-flash", etc.) to the canonical
                     // model id. Otherwise we'd persist "sonnet" and hand it
                     // straight to the Anthropic API, which replies
                     // `not_found_error: model: sonnet`.
@@ -3672,7 +3672,7 @@ mod tests {
         assert_eq!(default_model_for_provider("openai"), Some("gpt-4o"));
         assert_eq!(
             default_model_for_provider("gemini"),
-            Some("gemini-2.0-flash")
+            Some("gemini-2.5-flash")
         );
         assert_eq!(
             default_model_for_provider("ollama"),


### PR DESCRIPTION
## Summary

Update the native Gemini provider default model from `gemini-2.0-flash` to `gemini-2.5-flash`.

Closes #19

## Motivation

Google lists `gemini-2.0-flash` as deprecated and recommends `gemini-2.5-flash` as the replacement:

https://ai.google.dev/gemini-api/docs/deprecations

The issue wording says the model was retired in January 2026, but Google's current deprecation page lists the shutdown date as June 1, 2026. This PR still updates the default now so new Gemini sessions do not start on a deprecated model.

## Changes

- Change `ProviderKind::Gemini.default_model()` to `gemini-2.5-flash`
- Update the REPL default-provider test expectation
- Update the nearby alias-resolution comment from `gemini-2.0-flash` to `gemini-2.5-flash`
- Keep older Gemini models in the catalogue so explicit existing user configs remain selectable/detectable

## Test plan

How did you verify this works?

- [ ] `cargo test --features gui` passes locally — not run; local environment has no `cargo`/`rustc`
- [ ] `cargo fmt --check` passes — not run; local environment has no `cargo`/`rustc`
- [ ] `cargo clippy --features gui -- -D warnings` passes — not run; local environment has no `cargo`/`rustc`
- [ ] `cargo test -p thclaws-core default_model_for_provider_covers_all_supported` — attempted, blocked by `cargo: command not found`
- [ ] `cargo test -p thclaws-core resolve_alias_for_provider_stays_in_namespace` — attempted, blocked by `cargo: command not found`
- [ ] `cargo test -p thclaws-core detect_gemini_and_gemma_go_to_gemini` — attempted, blocked by `cargo: command not found`
- [ ] `cargo test -p thclaws-core --lib` — not run; local environment has no `cargo`/`rustc`
- [x] `git diff --check`

## Screenshots / recordings

Not applicable, provider default/model-selection behavior change only.

## Checklist

- [x] Tests added or updated
- [ ] Documentation updated if behavior changes — not applicable; no user-facing docs mention this default
- [ ] No new compiler warnings introduced — not verified locally because Rust toolchain is unavailable
- [x] PR scope is focused — no unrelated changes
- [x] Commits follow project style
