### PR TITLE
feat(anthropic): add third cache breakpoint on rolling conversation history

### DIFF
--- a/crates/core/src/providers/anthropic.rs
+++ b/crates/core/src/providers/anthropic.rs
@@ -54,7 +54,7 @@ impl AnthropicProvider {
     }
 
     fn build_body(req: &StreamRequest) -> Value {
-        let msgs: Vec<Value> = req
+        let mut msgs: Vec<Value> = req
             .messages
             .iter()
             .filter(|m| !matches!(m.role, Role::System))
@@ -69,6 +69,31 @@ impl AnthropicProvider {
                 })
             })
             .collect();
+
+        // Third cache breakpoint: tag the last content block of the
+        // second-to-last message so the rolling conversation history
+        // becomes a cached prefix on subsequent turns. The newest
+        // message is the live user turn (uncached by definition); the
+        // one before it is byte-stable across the next call. Skip
+        // when the history is too short — Anthropic's minimum
+        // cacheable prefix is 1024 tokens, so 1–2 messages rarely
+        // qualify and the breakpoint slot is better preserved for
+        // later turns. Anthropic allows up to 4 cache_control markers
+        // per request; this is the third (system + last tool are the
+        // other two).
+        if msgs.len() >= 3 {
+            let target_idx = msgs.len() - 2;
+            if let Some(content) = msgs[target_idx]
+                .get_mut("content")
+                .and_then(Value::as_array_mut)
+            {
+                if let Some(last_block) = content.last_mut() {
+                    if let Some(obj) = last_block.as_object_mut() {
+                        obj.insert("cache_control".into(), json!({"type": "ephemeral"}));
+                    }
+                }
+            }
+        }
 
         // Strip provider prefixes so the model name matches what the backend expects.
         let model = req
@@ -428,6 +453,88 @@ mod tests {
         let msgs = body["messages"].as_array().unwrap();
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0]["role"], "user");
+    }
+
+    #[test]
+    fn build_body_caches_second_to_last_message_when_history_long_enough() {
+        // Three-message rolling history: user/assistant/user. The
+        // assistant turn (index 1) is second-to-last and should carry
+        // the cache_control marker so its tail becomes a cached prefix
+        // on the next call. The newest user turn (index 2) must stay
+        // uncached.
+        let req = StreamRequest {
+            model: "claude-sonnet-4-5".into(),
+            system: Some("you are helpful".into()),
+            messages: vec![
+                Message::user("first"),
+                Message::assistant("reply"),
+                Message::user("second"),
+            ],
+            tools: vec![],
+            max_tokens: 1024,
+            thinking_budget: None,
+        };
+        let body = AnthropicProvider::build_body(&req);
+        let msgs = body["messages"].as_array().unwrap();
+        assert_eq!(msgs.len(), 3);
+        let second_to_last_last_block = msgs[1]["content"].as_array().unwrap().last().unwrap();
+        assert_eq!(
+            second_to_last_last_block["cache_control"]["type"],
+            "ephemeral"
+        );
+        for block in msgs[2]["content"].as_array().unwrap() {
+            assert!(
+                block.get("cache_control").is_none(),
+                "newest message must not carry cache_control"
+            );
+        }
+    }
+
+    #[test]
+    fn build_body_skips_message_cache_when_history_too_short() {
+        // Two-message history: the breakpoint slot is preserved for
+        // later turns. System + tools breakpoints still apply.
+        let req = StreamRequest {
+            model: "claude-sonnet-4-5".into(),
+            system: Some("sys".into()),
+            messages: vec![Message::user("first"), Message::assistant("reply")],
+            tools: vec![],
+            max_tokens: 1024,
+            thinking_budget: None,
+        };
+        let body = AnthropicProvider::build_body(&req);
+        for msg in body["messages"].as_array().unwrap() {
+            for block in msg["content"].as_array().unwrap() {
+                assert!(
+                    block.get("cache_control").is_none(),
+                    "no message cache_control when history < 3"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn build_body_message_cache_is_byte_stable_across_calls() {
+        // Same input twice → identical body. Guards against silent
+        // cache busts from non-deterministic field ordering.
+        let req = StreamRequest {
+            model: "claude-sonnet-4-5".into(),
+            system: Some("sys".into()),
+            messages: vec![
+                Message::user("a"),
+                Message::assistant("b"),
+                Message::user("c"),
+            ],
+            tools: vec![],
+            max_tokens: 100,
+            thinking_budget: None,
+        };
+        let a = AnthropicProvider::build_body(&req);
+        let b = AnthropicProvider::build_body(&req);
+        assert_eq!(
+            serde_json::to_string(&a).unwrap(),
+            serde_json::to_string(&b).unwrap()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add a third Anthropic `cache_control: ephemeral` breakpoint on the last content block of the second-to-last message, turning the rolling conversation history into a cached prefix on subsequent turns.

## Motivation

Today `build_body` places two cache breakpoints — system prompt and last tool definition (`anthropic.rs:87-113`). Both cache *fixed-size* blocks. The growing conversation history is re-tokenized in full on every turn even though everything except the newest user message is byte-stable across the next call.

Anthropic supports up to 4 `cache_control` markers per request and we were using only 2. For interactive coding sessions, the third breakpoint changes the input-cost growth from O(N²) (every turn re-bills the full history at 1.0×) to O(N) (each turn pays cache_read at 0.10× on cumulative history plus cache_write at 1.25× on the delta).

Rough cost reductions on Sonnet 4.6 input cost vs. the current 2-breakpoint setup:

| Session length × shape | Saving vs 2-bp |
|---|---|
| 10 turns, normal coding | ~46% |
| 10 turns, tool-heavy | ~54% |
| 30 turns, normal coding | ~74% |

Break-even is one cache hit: the 25% write surcharge is recovered the next time the cached prefix is reused at 90% off.

## Anthropic's 1024-token hard floor

Anthropic's server **silently ignores `cache_control` markers when the cached prefix is shorter than 1024 tokens** (Sonnet/Opus; 2048 for Haiku). This is a server-side constraint, not a client guard. Practical implications:

- The marker is harmless when the prefix is small — no charge, no benefit, no error.
- The `len >= 3` guard in this PR is a *soft* skip to avoid spending the breakpoint slot on histories that almost certainly won't qualify yet. The hard floor is server-side.
- For typical thClaws usage the floor is crossed quickly: turn 1 for tool-heavy sessions, turn 2 for normal coding (S+T+messages already exceed 6K tokens after one round), turn 5–6 for pure-text chat.

## Changes

- `crates/core/src/providers/anthropic.rs`:
  - Tag the last content block of `msgs[len - 2]` with `cache_control: { type: "ephemeral" }` when `msgs.len() >= 3`.
  - Newest message (live user turn) is left uncached by definition.
  - Skip when history is too short — preserves the breakpoint slot for later turns. Hard 1024-token floor is enforced server-side.
  - No public API change. Affects only the request body shape.

## Test plan

Three new tests in `providers::anthropic::tests`:

- `build_body_caches_second_to_last_message_when_history_long_enough` — 3-message history; asserts `msgs[1]` last block carries `cache_control: ephemeral` and `msgs[2]` (newest) does not.
- `build_body_skips_message_cache_when_history_too_short` — 2-message history; asserts no message-level `cache_control` added.
- `build_body_message_cache_is_byte_stable_across_calls` — same input twice → identical serialized body. Guards against silent cache busts from non-deterministic field ordering.

- [x] `cargo test -p thclaws-core --lib --features gui` passes locally — **496/496 pass** including 18 anthropic tests (3 new)
- [x] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --features gui -- -D warnings` — fails on 2 pre-existing errors in `crates/core/build.rs` (`collapsible_str_replace`, `manual_div_ceil`) that exist on plain `main` without this change. **Not introduced by this PR.**

## Checklist

- [x] Tests added (3 unit tests covering positive case, guard, and byte-stability invariant)
- [x] No new compiler warnings introduced
- [x] PR scope focused — single-purpose change to `anthropic.rs`
- [x] Commit follows project style (`feat(anthropic): ...`)

## Prior art

This three-breakpoint layout (cache on system, on the last tool definition, and on the rolling `messages[-2]`) is a known pattern in production Anthropic clients. The placement on the second-to-last message — not the last — is deliberate: the newest message is the live user turn, which is by definition uncached, while the one before it is byte-stable across the next call and becomes the cache anchor.