### PR TITLE
fix(terminal): prevent Tab focus escape and force-close popup on accept

### DIFF
--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -87,7 +87,7 @@ export function ChatView() {
   // streaming turn — slash commands fire instantly so there's nothing
   // useful to autocomplete while the model is still talking.
   const slashOpen =
-    !askPrompt && !streaming && input.startsWith("/");
+    !askPrompt && !streaming && input.startsWith("/") && !input.slice(1).includes(" ");
   const slashQuery = slashOpen ? input.slice(1).split(/\s/)[0] : "";
   const slashFiltered = slashOpen
     ? filterCommands(slashCommands, slashQuery)
@@ -389,11 +389,10 @@ export function ChatView() {
   };
 
   const acceptSlashCommand = (cmd: SlashCommandInfo) => {
-    // Commands with required args (usage non-empty and not optional)
-    // get the slash + name + trailing space inserted so the user can
-    // immediately type the argument. Zero-arg commands fire on enter.
-    const needsArg = cmd.usage && !cmd.usage.startsWith("[");
-    setInput(`/${cmd.name}${needsArg ? " " : ""}`);
+    // Always append a trailing space so the popup closes (slashOpen
+    // checks for space) and the user can immediately type args or
+    // press Enter.
+    setInput(`/${cmd.name} `);
     setSlashIndex(0);
     inputRef.current?.focus();
   };

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -185,9 +185,9 @@ export function TerminalView({ active }: Props) {
       setSlashView({ open: true, query, index, filtered });
     };
 
-    // Accept a command into the line buffer + visible terminal. Args-
-    // required commands (e.g. /model NAME) get a trailing space so the
-    // user can keep typing; zero-arg commands stop at the name.
+    // Accept a command into the line buffer + visible terminal. Always
+    // appends a trailing space so the popup closes and the user can
+    // immediately type args or press Enter.
     const acceptSlashCommand = (cmd: SlashCommandInfo) => {
       const next = `/${cmd.name} `;
       term.write("\x1b[2K\r");

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -189,19 +189,13 @@ export function TerminalView({ active }: Props) {
     // required commands (e.g. /model NAME) get a trailing space so the
     // user can keep typing; zero-arg commands stop at the name.
     const acceptSlashCommand = (cmd: SlashCommandInfo) => {
-      const needsArg = cmd.usage && !cmd.usage.startsWith("[");
-      const next = `/${cmd.name}${needsArg ? " " : ""}`;
+      const next = `/${cmd.name} `;
       term.write("\x1b[2K\r");
       writePrompt();
       lineBuffer = next;
-      // Keep cursorPos in lockstep with the visible xterm cursor.
-      // Without this the user's next keystroke inserts mid-command
-      // (closes #31): Tab/mouse "selects" the command, but cursorPos
-      // stays at the pre-accept position (e.g. 2 after typing "/s"),
-      // so typing arguments mangles the command name.
       cursorPos = next.length;
       term.write(next);
-      recomputeSlash();
+      setSlashView(SLASH_VIEW_CLOSED);
     };
     acceptSlashRef.current = acceptSlashCommand;
 
@@ -265,6 +259,7 @@ export function TerminalView({ active }: Props) {
             return false;
           }
           if (e.key === "Tab") {
+            e.preventDefault();
             const cmd = sv.filtered[sv.index];
             if (cmd) acceptSlashCommand(cmd);
             return false;


### PR DESCRIPTION
## Summary

Fix remaining slash-command popup issues in both the Terminal and Chat tabs that were not addressed by the `cursorPos` fix in v0.6.2.

## Motivation

Relates to #31 — the `cursorPos` fix (55a505b) resolved cursor misplacement after selecting a command, but three issues remain:

1. **Tab focus escape (Terminal)**: pressing Tab to accept a command moves DOM focus out of the terminal (to the next focusable element) because `e.preventDefault()` was never called — `return false` only tells xterm to skip processing, it does not prevent the browser's default Tab behavior.
2. **Popup stays open after accept (Terminal)**: `acceptSlashCommand` called `recomputeSlash()` to close the popup, but zero-arg commands like `/help` produce a `lineBuffer` without a space, which `recomputeSlash` interprets as "still composing" and keeps the popup open.
3. **Popup stays open after accept (Chat)**: `slashOpen` is a derived value that only checks `input.startsWith("/")` — after accepting a command the input still starts with `/`, so the popup stays open.

## Changes

**TerminalView.tsx**
- Add `e.preventDefault()` before `return false` in the Tab key handler so the browser does not perform focus navigation.
- Replace `recomputeSlash()` with `setSlashView(SLASH_VIEW_CLOSED)` in `acceptSlashCommand` to unconditionally close the popup after selection.
- Always append a trailing space after the accepted command name for consistent UX.

**ChatView.tsx**
- Add `!input.slice(1).includes(" ")` check to `slashOpen` so the popup closes when a command with a trailing space is accepted.
- Always append a trailing space after the accepted command name, matching Terminal behavior.

## Test plan

- [x] Frontend type-check passes (`cd frontend && pnpm tsc --noEmit`)
- [x] Manually exercised the feature — steps:
  1. Terminal tab → type `/` → press **Tab** → focus stays in terminal (does not jump to folder icon)
  2. Type `/he` → press **Tab** → popup disappears, input shows `/help ` with cursor at end
  3. Type `/mo` → press **Tab** → input shows `/model `, type `gpt-5` → text appends correctly
  4. Type `/` → **click** a command from popup → same behavior as Tab
  5. Chat tab → type `/` → press **Tab** → popup disappears
  6. Chat tab → type `/he` → press **Tab** → popup disappears, input shows `/help `
  7. Clear input → type `/` again → popup reappears

https://github.com/user-attachments/assets/f5c7f8df-0012-4010-b786-9efecc071cd2