### PR TITLE
fix(frontend): return focus to active tab after modal close and tab switch

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -372,6 +372,7 @@ export default function App() {
     return unsub;
   }, []);
 
+  const modalOpen = showSettings || instructionsScope !== null || modelPicker !== null;
   const effectiveTab = (!teamEnabled && activeTab === "team") ? "chat" as Tab : activeTab;
 
   const TABS = teamEnabled ? ALL_TABS : ALL_TABS.filter((t) => t.id !== "team");
@@ -456,8 +457,8 @@ export default function App() {
             const cls = `absolute inset-0 ${isActive ? "" : "invisible pointer-events-none"}`;
             return (
               <div key={id} className={cls}>
-                {id === "terminal" && <TerminalView active={isActive} />}
-                {id === "chat" && <ChatView />}
+                {id === "terminal" && <TerminalView active={isActive} modalOpen={modalOpen} />}
+                {id === "chat" && <ChatView active={isActive} modalOpen={modalOpen} />}
                 {id === "files" && <FilesView active={isActive} />}
                 {id === "team" && <TeamView />}
               </div>

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -63,7 +63,12 @@ function blobToBase64(blob: Blob): Promise<string> {
   });
 }
 
-export function ChatView() {
+type Props = {
+  active: boolean;
+  modalOpen: boolean;
+};
+
+export function ChatView({ active, modalOpen }: Props) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
   const [streaming, setStreaming] = useState(false);
@@ -329,6 +334,11 @@ export function ChatView() {
     // either render off-screen or wrap unexpectedly.
     setSlashIndex(0);
   }, [slashQuery, slashOpen]);
+
+  // Focus the input when the tab becomes active or a modal closes.
+  useEffect(() => {
+    if (active && !modalOpen) inputRef.current?.focus();
+  }, [active, modalOpen]);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -54,6 +54,7 @@ const PROMPT = "\x1b[32m❯ \x1b[0m";
 
 interface Props {
   active: boolean;
+  modalOpen: boolean;
 }
 
 function b64decode(s: string): Uint8Array {
@@ -63,7 +64,7 @@ function b64decode(s: string): Uint8Array {
   return out;
 }
 
-export function TerminalView({ active }: Props) {
+export function TerminalView({ active, modalOpen }: Props) {
   const ref = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
@@ -653,9 +654,9 @@ export function TerminalView({ active }: Props) {
     };
   }, []);
 
-  // Refit + focus when the tab becomes active.
+  // Refit + focus when the tab becomes active or a modal closes.
   useEffect(() => {
-    if (!active) return;
+    if (!active || modalOpen) return;
     const t = termRef.current;
     const f = fitRef.current;
     if (!t) return;
@@ -663,7 +664,7 @@ export function TerminalView({ active }: Props) {
       try { f?.fit(); } catch { /* fit() may throw on zero-size or disposed container */ }
       t.focus();
     });
-  }, [active]);
+  }, [active, modalOpen]);
 
   // Live theme swap.
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fix focus not returning to the active tab's input after closing a modal or switching tabs.

## Motivation

When a modal (Settings, Model Picker, Instructions Editor) closes, focus is left in limbo — the user has to click the input or terminal to resume typing. Similarly, switching to the Chat tab doesn't auto-focus its input, unlike Terminal which already had this behavior.

## Changes

**App.tsx**
- Add `modalOpen` derived from `showSettings`, `instructionsScope`, and `modelPicker` state.
- Pass `modalOpen` prop to `ChatView` and `TerminalView`.

**ChatView.tsx**
- Accept `active` and `modalOpen` props.
- Auto-focus input when `active && !modalOpen` — covers both tab switch and modal close.

**TerminalView.tsx**
- Accept `modalOpen` prop alongside existing `active`.
- Extend the existing refit+focus effect to also trigger when `modalOpen` changes to false.

## Test plan

- [x] Frontend type-check passes (`cd frontend && pnpm tsc --noEmit`)
- [x] Manually exercised the feature — steps:
  1. Terminal tab → open Settings → close → focus returns to terminal
  2. Chat tab → `/model` → Enter → close Model Picker → focus returns to chat input
  3. Click Terminal tab → click Chat tab → cursor is in chat input, ready to type
  4. Chat tab → open Instructions Editor → close → focus returns to chat input