### PR TITLE
feat: implicit thinking fix + Thai font fallbacks

### DIFF
--- a/crates/core/src/providers/assemble.rs
+++ b/crates/core/src/providers/assemble.rs
@@ -46,12 +46,137 @@ pub struct TurnResult {
 enum BlockState {
     None,
     Text,
-    Thinking,
     ToolUse {
         id: String,
         name: String,
         buf: String,
     },
+}
+
+/// Returns true for model families known to emit *implicit* reasoning —
+/// they start streaming chain-of-thought text with no opening `<think>`,
+/// then close it with `</think>` before the actual answer. We use this to
+/// gate the lookahead-buffer hack in `assemble`. Be conservative: only the
+/// specific families that need it. Other families (qwen2.5-coder, qwen-vl,
+/// generic *r1 finetunes) must NOT match or every turn pays a 1KB delay.
+fn is_implicit_thinking_model(model: &str) -> bool {
+    let m = model.to_lowercase();
+    // Qwen3 thinking variants. Plain "qwen" / "qwen2" must not match.
+    if m.contains("qwen3") || m.contains("qwq") {
+        return true;
+    }
+    // DeepSeek R1 family (and OpenRouter prefix form).
+    if m.contains("deepseek-r1") || m.contains("deepseek/deepseek-r1") {
+        return true;
+    }
+    false
+}
+
+/// Streaming state for `split_think_text`. Persists across SSE chunks so
+/// tags split on chunk boundaries — and the blank lines Qwen3-style models
+/// emit between `</think>` and the answer — are handled correctly.
+#[derive(Default)]
+struct ThinkState {
+    in_block: bool,
+    tag_buf: String,
+    /// Set right after a `</think>` is consumed. Strips leading newlines
+    /// from the next text the model emits, in case `</think>\n\n` straddles
+    /// two SSE chunks.
+    trim_leading_newlines: bool,
+}
+
+/// Split a text chunk that may contain `<think>…</think>` blocks into the
+/// appropriate `AssembledEvent`s. Any text inside the tags becomes
+/// `Thinking`; text outside becomes `Text`.
+fn split_think_text(chunk: &str, state: &mut ThinkState) -> Vec<AssembledEvent> {
+    let mut out = Vec::new();
+    let mut combined = if state.tag_buf.is_empty() {
+        chunk.to_string()
+    } else {
+        format!("{}{}", std::mem::take(&mut state.tag_buf), chunk)
+    };
+    if state.trim_leading_newlines && !state.in_block {
+        let trimmed = combined.trim_start_matches('\n');
+        if trimmed.len() < combined.len() {
+            combined = trimmed.to_string();
+        }
+        if !combined.is_empty() {
+            state.trim_leading_newlines = false;
+        }
+    }
+    let mut s = combined.as_str();
+    loop {
+        if s.is_empty() {
+            break;
+        }
+        if state.in_block {
+            const CLOSE: &str = "</think>";
+            if let Some(pos) = s.find(CLOSE) {
+                if pos > 0 {
+                    out.push(AssembledEvent::Thinking(s[..pos].to_string()));
+                }
+                state.in_block = false;
+                let after = &s[pos + CLOSE.len()..];
+                let trimmed = after.trim_start_matches('\n');
+                // If nothing remains after stripping newlines in this chunk,
+                // remember to strip leading newlines from the next chunk too.
+                state.trim_leading_newlines = trimmed.is_empty();
+                s = trimmed;
+            } else {
+                let keep = longest_tag_prefix(s, CLOSE);
+                if s.len() > keep {
+                    out.push(AssembledEvent::Thinking(s[..s.len() - keep].to_string()));
+                }
+                if keep > 0 {
+                    state.tag_buf.push_str(&s[s.len() - keep..]);
+                }
+                break;
+            }
+        } else {
+            const OPEN: &str = "<think>";
+            const CLOSE: &str = "</think>";
+            if let Some(pos) = s.find(OPEN) {
+                if pos > 0 {
+                    out.push(AssembledEvent::Text(s[..pos].to_string()));
+                }
+                state.in_block = true;
+                s = s[pos + OPEN.len()..].trim_start_matches('\n');
+            } else if let Some(pos) = s.find(CLOSE) {
+                // Found </think> but we weren't in a think block. This happens
+                // with models (like Qwen3) where the opening <think> is pre-filled
+                // in the prompt. Treat preceding text in this chunk as thinking.
+                if pos > 0 {
+                    out.push(AssembledEvent::Thinking(s[..pos].to_string()));
+                }
+                let after = &s[pos + CLOSE.len()..];
+                let trimmed = after.trim_start_matches('\n');
+                state.trim_leading_newlines = trimmed.is_empty();
+                s = trimmed;
+            } else {
+                let keep = longest_tag_prefix(s, OPEN);
+                if s.len() > keep {
+                    out.push(AssembledEvent::Text(s[..s.len() - keep].to_string()));
+                }
+                if keep > 0 {
+                    state.tag_buf.push_str(&s[s.len() - keep..]);
+                }
+                break;
+            }
+        }
+    }
+    out
+}
+
+fn longest_tag_prefix(haystack: &str, needle: &str) -> usize {
+    let h = haystack.as_bytes();
+    let n = needle.as_bytes();
+    let max = h.len().min(n.len() - 1);
+    for len in (1..=max).rev() {
+        if h[h.len() - len..] == n[..len] {
+            return len;
+        }
+    }
+    0
 }
 
 pub fn assemble<S>(inner: S) -> impl Stream<Item = Result<AssembledEvent>> + Send + 'static
@@ -60,17 +185,30 @@ where
 {
     try_stream! {
         let mut state = BlockState::None;
+        // For implicit-thinking models (Qwen3, DeepSeek-R1) the stream begins
+        // with reasoning that has no opening `<think>` tag — only a closing
+        // `</think>` before the answer. Pre-seed `in_block = true` so
+        // `split_think_text` emits the prefix as Thinking until it finds
+        // `</think>`. If the closing tag never arrives, the whole stream
+        // stays in Thinking and no chain-of-thought leaks as Text.
+        let mut think = ThinkState::default();
+
         let mut inner = Box::pin(inner);
         while let Some(ev) = inner.next().await {
             let ev = ev?;
             match ev {
-                ProviderEvent::MessageStart { .. } => {}
+                ProviderEvent::MessageStart { model } => {
+                    if is_implicit_thinking_model(&model) {
+                        think.in_block = true;
+                    }
+                }
                 ProviderEvent::TextDelta(s) => {
                     state = BlockState::Text;
-                    yield AssembledEvent::Text(s);
+                    for ev in split_think_text(&s, &mut think) {
+                        yield ev;
+                    }
                 }
                 ProviderEvent::ThinkingDelta(s) => {
-                    state = BlockState::Thinking;
                     yield AssembledEvent::Thinking(s);
                 }
                 ProviderEvent::ToolUseStart { id, name } => {
@@ -292,6 +430,123 @@ mod tests {
         } else {
             panic!("expected ToolUse");
         }
+    }
+
+    #[test]
+    fn implicit_thinking_detection_is_specific() {
+        // Should match: qwen3 family, qwq, deepseek-r1 family.
+        assert!(is_implicit_thinking_model("qwen3-30b-a3b-thinking"));
+        assert!(is_implicit_thinking_model("qwen/qwen3-235b"));
+        assert!(is_implicit_thinking_model("qwq-32b-preview"));
+        assert!(is_implicit_thinking_model("deepseek-r1"));
+        assert!(is_implicit_thinking_model("deepseek/deepseek-r1-distill"));
+
+        // Must NOT match: non-thinking qwen variants and unrelated -r1 ids.
+        assert!(!is_implicit_thinking_model("qwen2.5-coder-32b"));
+        assert!(!is_implicit_thinking_model("qwen-vl-plus"));
+        assert!(!is_implicit_thinking_model("qwen-turbo"));
+        assert!(!is_implicit_thinking_model("gpt-4o"));
+        assert!(!is_implicit_thinking_model("anthropic/claude-sonnet-4-6"));
+    }
+
+    #[test]
+    fn split_think_text_handles_lone_closing_tag() {
+        let mut state = ThinkState::default();
+
+        // Case: starts with reasoning (no <think>) and ends with </think>
+        let ev = split_think_text("reasoning here </think>actual answer", &mut state);
+        assert!(!state.in_block);
+        let thinking: Vec<_> = ev.iter().filter_map(|e| if let AssembledEvent::Thinking(s) = e { Some(s.as_str()) } else { None }).collect();
+        let text: Vec<_> = ev.iter().filter_map(|e| if let AssembledEvent::Text(s) = e { Some(s.as_str()) } else { None }).collect();
+
+        assert_eq!(thinking.join(""), "reasoning here ");
+        assert_eq!(text.join(""), "actual answer");
+    }
+
+    #[test]
+    fn split_think_text_strips_newlines_across_chunk_boundary() {
+        // Real Qwen3 / vLLM behavior: `</think>` ends one SSE chunk and the
+        // next chunk starts with `\n\n`. The blank lines must not leak into
+        // the rendered Text.
+        let mut state = ThinkState {
+            in_block: true,
+            ..Default::default()
+        };
+        let ev1 = split_think_text("</think>", &mut state);
+        let ev2 = split_think_text("\n\nHi.", &mut state);
+
+        let text: String = ev1
+            .iter()
+            .chain(ev2.iter())
+            .filter_map(|e| {
+                if let AssembledEvent::Text(s) = e {
+                    Some(s.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(text, "Hi.");
+    }
+
+    #[tokio::test]
+    async fn implicit_thinking_routes_prefix_to_thinking() {
+        // Qwen3 streams reasoning then `</think>` then answer, with no
+        // opening tag. Reasoning must land in `thinking`, not `text`.
+        let r = collected(vec![
+            ProviderEvent::MessageStart {
+                model: "qwen3.6-35b-a3b-fp8".into(),
+            },
+            ProviderEvent::TextDelta("let me think about this".into()),
+            ProviderEvent::TextDelta(" carefully</think>".into()),
+            ProviderEvent::TextDelta("Final answer.".into()),
+            ProviderEvent::ContentBlockStop,
+            ProviderEvent::MessageStop {
+                stop_reason: Some("end_turn".into()),
+                usage: None,
+            },
+        ])
+        .await;
+        assert_eq!(r.thinking, "let me think about this carefully");
+        assert_eq!(r.text, "Final answer.");
+    }
+
+    #[tokio::test]
+    async fn implicit_thinking_without_close_stays_in_thinking() {
+        // Degenerate case: stream ends mid-reasoning. The chain-of-thought
+        // must NOT leak as `text` — keep it in `thinking`.
+        let r = collected(vec![
+            ProviderEvent::MessageStart {
+                model: "qwen3-30b".into(),
+            },
+            ProviderEvent::TextDelta("step 1, step 2, step 3".into()),
+            ProviderEvent::MessageStop {
+                stop_reason: Some("end_turn".into()),
+                usage: None,
+            },
+        ])
+        .await;
+        assert_eq!(r.text, "");
+        assert_eq!(r.thinking, "step 1, step 2, step 3");
+    }
+
+    #[tokio::test]
+    async fn non_thinking_model_passes_text_through() {
+        // qwen2.5-coder must not be detected as implicit-thinking — its
+        // output is plain text and should not be re-routed.
+        let r = collected(vec![
+            ProviderEvent::MessageStart {
+                model: "qwen2.5-coder-32b".into(),
+            },
+            ProviderEvent::TextDelta("hello world".into()),
+            ProviderEvent::MessageStop {
+                stop_reason: Some("end_turn".into()),
+                usage: None,
+            },
+        ])
+        .await;
+        assert_eq!(r.text, "hello world");
+        assert_eq!(r.thinking, "");
     }
 
     #[tokio::test]

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -50,6 +50,17 @@ function dataUrlToBase64(dataUrl: string): string {
   return idx >= 0 ? dataUrl.slice(idx + 1) : dataUrl;
 }
 
+/// Remove `<think>...</think>` blocks from rendered text. The backend's
+/// assembler now routes thinking into a separate ContentBlock, but old
+/// persisted sessions may still have the tags embedded — strip them here.
+/// Only paired tags are removed (no lazy "swallow up to next </think>"
+/// that could eat ordinary user content containing a literal tag).
+const THINK_BLOCK = /<think>[\s\S]*?<\/think>\n?/gi;
+const ORPHAN_CLOSE = /^[ \t\r\n]*<\/think>\n?/i;
+function stripThinkBlocks(content: string): string {
+  return content.replace(THINK_BLOCK, "").replace(ORPHAN_CLOSE, "");
+}
+
 function blobToBase64(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -408,6 +419,12 @@ export function ChatView({ active, modalOpen }: Props) {
   };
 
   const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // Prevent form submit while IME is composing (Thai, Japanese, Chinese, etc.).
+    // Enter during composition should commit the character, not send the message.
+    if (e.key === "Enter" && e.nativeEvent.isComposing) {
+      e.preventDefault();
+      return;
+    }
     if (!slashOpen || slashFiltered.length === 0) return;
     if (e.key === "ArrowDown") {
       e.preventDefault();
@@ -489,7 +506,8 @@ export function ChatView({ active, modalOpen }: Props) {
                   className="group inline-flex max-w-[80%] items-center gap-1 text-xs"
                   style={{
                     color: "var(--text-secondary)",
-                    fontFamily: "Menlo, Monaco, monospace",
+                    fontFamily:
+                      "Menlo, Monaco, 'Courier New', 'Noto Sans Mono', 'Tlwg Mono', 'Loma', 'Noto Sans Thai', monospace",
                     paddingLeft: 2,
                     opacity: msg.toolDone ? 0.7 : 1,
                   }}
@@ -531,7 +549,9 @@ export function ChatView({ active, modalOpen }: Props) {
                         ? "var(--text-secondary)"
                         : "var(--text-primary)",
                   border: isSystem ? "1px solid var(--border)" : "none",
-                  fontFamily: isSystem ? "Menlo, Monaco, monospace" : "inherit",
+                  fontFamily: isSystem
+                    ? "Menlo, Monaco, 'Courier New', 'Noto Sans Mono', 'Tlwg Mono', 'Loma', 'Noto Sans Thai', monospace"
+                    : "inherit",
                   fontSize: isSystem ? "12px" : "14px",
                 }}
               >
@@ -557,7 +577,7 @@ export function ChatView({ active, modalOpen }: Props) {
                       remarkPlugins={[remarkGfm]}
                       rehypePlugins={[rehypeHighlight]}
                     >
-                      {msg.content}
+                      {stripThinkBlocks(msg.content)}
                     </ReactMarkdown>
                   </div>
                 ) : (

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -128,7 +128,8 @@ export function CodeEditor({
       EditorView.theme({
         "&": { height: "100%", fontSize: "13px" },
         ".cm-scroller": {
-          fontFamily: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+          fontFamily:
+            "ui-monospace, SFMono-Regular, Menlo, Consolas, 'Noto Sans Mono', 'Tlwg Mono', 'Loma', 'Noto Sans Thai', monospace",
         },
       }),
     ];

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -101,7 +101,7 @@ export function TerminalView({ active, modalOpen }: Props) {
     if (!ref.current || termRef.current) return;
 
     const term = new Terminal({
-      fontFamily: "Menlo, Monaco, 'Courier New', monospace",
+      fontFamily: "Menlo, Monaco, 'Courier New', 'Noto Sans Mono', 'Noto Sans Thai', monospace",
       fontSize: 13,
       cursorBlink: true,
       scrollback: 10000,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -49,7 +49,7 @@ html, body, #root {
   height: 100%;
   background: var(--bg-primary);
   color: var(--text-primary);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans Thai", "Sarabun", "Loma", "Garuda", "Tahoma", sans-serif;
   overflow: hidden;
 }
 
@@ -106,7 +106,7 @@ html, body, #root {
   background: var(--bg-tertiary);
   padding: 0.12em 0.32em;
   border-radius: 3px;
-  font-family: Menlo, Monaco, "Courier New", monospace;
+  font-family: Menlo, Monaco, "Courier New", "Noto Sans Mono", "Tlwg Mono", "Loma", "Noto Sans Thai", monospace;
   font-size: 0.9em;
 }
 .markdown-body pre {


### PR DESCRIPTION
- Fix Qwen3/DeepSeek-R1 cross-chunk newline leak after </think> via ThinkState struct; strip leading \n across SSE chunk boundary
- Add Thai font fallbacks to CSS stacks (Noto Sans Thai, Loma, etc.) for Chat/Code/Terminal views on Linux WebKitGTK

🤖 Generated with AI

## Summary

Briefly describe what this PR does.

## Motivation

Why is this change needed? Link the issue it closes (e.g. `Closes #123`).

## Changes

- ...
- ...

## Test plan

How did you verify this works?

- [ ] `cargo test --features gui` passes locally
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --features gui -- -D warnings` passes
- [ ] Frontend type-check passes (`cd frontend && pnpm tsc --noEmit`) — if frontend touched
- [ ] Manually exercised the feature — steps:
  1. ...
  2. ...

## Screenshots / recordings

For GUI / CLI UX changes, include a before / after screenshot or short recording.

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if behavior changes (README / CHANGELOG / in-repo docs)
- [ ] No new compiler warnings introduced
- [ ] PR scope is focused — no unrelated changes
- [ ] Commits follow project style (concise, imperative, optional `feat/fix/docs/...` prefix)
