### PR TITLE
Fix/windows

### DIFF
--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -59,9 +59,7 @@ impl GitInfo {
 
             cmd.args(args).current_dir(cwd);
 
-            let out = cmd
-                .output()
-                .ok()?;
+            let out = cmd.output().ok()?;
 
             if !out.status.success() {
                 return None;

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -10,6 +10,10 @@ use crate::error::Result;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+// for Windows creation flag to hide the console window
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GitInfo {
     pub branch: String,
@@ -47,11 +51,18 @@ impl GitInfo {
     /// or if git is not installed.
     pub fn from_cwd(cwd: &Path) -> Option<Self> {
         let run = |args: &[&str]| -> Option<String> {
-            let out = Command::new("git")
-                .args(args)
-                .current_dir(cwd)
+            let mut cmd = Command::new("git");
+
+            // for Windows creation flag to hide the console window
+            #[cfg(target_os = "windows")]
+            cmd.creation_flags(0x08000000);
+
+            cmd.args(args).current_dir(cwd);
+
+            let out = cmd
                 .output()
                 .ok()?;
+
             if !out.status.success() {
                 return None;
             }

--- a/crates/core/src/oauth.rs
+++ b/crates/core/src/oauth.rs
@@ -618,8 +618,10 @@ fn open_browser(url: &str) {
     }
     #[cfg(target_os = "windows")]
     {
+        use std::os::windows::process::CommandExt;
         let _ = std::process::Command::new("cmd")
             .args(["/c", "start", url])
+            .creation_flags(0x08000000)
             .spawn();
     }
 }

--- a/crates/core/src/sso/mod.rs
+++ b/crates/core/src/sso/mod.rs
@@ -445,6 +445,7 @@ fn url_encode(s: &str) -> String {
 
 fn open_browser(url: &str) -> std::io::Result<()> {
     use std::process::Command;
+    
     #[cfg(target_os = "macos")]
     let mut cmd = {
         let mut c = Command::new("open");
@@ -463,6 +464,14 @@ fn open_browser(url: &str) -> std::io::Result<()> {
         c.args(["/C", "start", "", url]);
         c
     };
+    
+    #[cfg(target_os = "windows")]
+    use std::os::windows::process::CommandExt;
+
+    // for Windows creation flag to hide the console window
+    #[cfg(target_os = "windows")]
+    cmd.creation_flags(0x08000000);
+    
     cmd.spawn()?;
     Ok(())
 }

--- a/crates/core/src/sso/mod.rs
+++ b/crates/core/src/sso/mod.rs
@@ -445,7 +445,7 @@ fn url_encode(s: &str) -> String {
 
 fn open_browser(url: &str) -> std::io::Result<()> {
     use std::process::Command;
-    
+
     #[cfg(target_os = "macos")]
     let mut cmd = {
         let mut c = Command::new("open");
@@ -464,14 +464,14 @@ fn open_browser(url: &str) -> std::io::Result<()> {
         c.args(["/C", "start", "", url]);
         c
     };
-    
+
     #[cfg(target_os = "windows")]
     use std::os::windows::process::CommandExt;
 
     // for Windows creation flag to hide the console window
     #[cfg(target_os = "windows")]
     cmd.creation_flags(0x08000000);
-    
+
     cmd.spawn()?;
     Ok(())
 }

--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -3,6 +3,10 @@
 
 use std::path::PathBuf;
 
+// for Windows creation flag to hide the console window
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+
 /// The current user's home directory, in a form that works on both
 /// Unix and Windows.
 ///
@@ -121,6 +125,11 @@ pub fn shell_command_sync(command: &str) -> std::process::Command {
     let (shell, flag) = shell_invocation();
     let mut c = std::process::Command::new(shell);
     c.arg(flag).arg(command);
+
+    // for Windows creation flag to hide the console window
+    #[cfg(target_os = "windows")]
+    c.creation_flags(0x08000000);
+
     c
 }
 
@@ -130,6 +139,11 @@ pub fn shell_command_async(command: &str) -> tokio::process::Command {
     let (shell, flag) = shell_invocation();
     let mut c = tokio::process::Command::new(shell);
     c.arg(flag).arg(command);
+
+    // for Windows creation flag to hide the console window
+    #[cfg(target_os = "windows")]
+    c.creation_flags(0x08000000);
+
     c
 }
 


### PR DESCRIPTION
## Summary

To hide the console window when spawning a proces on Windows.

## Motivation

While the application is in use, a terminal console window will appear and interfering.

## Changes

- Import the Extension Trait: Import std::os::windows::process::CommandExt to expose the creation_flags method on the std::process::Command and tokio::process::Command struct.
- Set the Flag: Use the constant CREATE_NO_WINDOW (value 0x08000000) within the creation_flags method.
- Conditional Compilation: Wrap the Windows-specific code in #[cfg(windows)] to ensure your project still compiles on other platforms like Linux or macOS.

## Test plan

- test git: ! git status
- test open web browser: ! start https://github.com/thClaws
- requirement: install Git for Windows from https://gitforwindows.org

