### PR TITLE
ci: run cargo-audit on every PR

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -3,16 +3,8 @@ name: cargo-audit
 on:
   push:
     branches: [main]
-    paths:
-      - 'Cargo.lock'
-      - 'crates/**/Cargo.toml'
-      - '.github/workflows/cargo-audit.yml'
   pull_request:
     branches: [main]
-    paths:
-      - 'Cargo.lock'
-      - 'crates/**/Cargo.toml'
-      - '.github/workflows/cargo-audit.yml'
   schedule:
     - cron: '0 5 * * 1'  # Mondays 05:00 UTC
 


### PR DESCRIPTION
## Summary

The `cargo-audit` workflow had a `paths:` filter limiting it to PRs that touched `Cargo.lock` or `crates/**/Cargo.toml`. The branch ruleset, however, requires the `audit` status check on every PR — so any PR touching only `.rs` files (e.g. #55) was permanently blocked from merging because the required check never ran.

Drop the path filter so audit runs on every push/PR to main.

## Test plan

- [x] This PR itself doesn't touch Cargo.lock — under the old filter it would have skipped audit; with this change it should now run.