### PR TITLE
fix: escape \u2028, \u2029, and \0 in escape_for_js

### DIFF
--- a/crates/core/src/gui.rs
+++ b/crates/core/src/gui.rs
@@ -1103,6 +1103,9 @@ fn escape_for_js(s: &str) -> String {
         .replace('\'', "\\'")
         .replace('\n', "\\n")
         .replace('\r', "\\r")
+        .replace('\0', "\\0")
+        .replace('\u{2028}', "\\u2028")
+        .replace('\u{2029}', "\\u2029")
 }
 
 #[cfg(target_os = "macos")]
@@ -2954,7 +2957,7 @@ pub fn run_gui() {
                 });
                 let js = format!(
                     "window.__thclaws_dispatch('{}')",
-                    state.to_string().replace('\\', "\\\\").replace('\'', "\\'")
+                    escape_for_js(&state.to_string())
                 );
                 let _ = webview.evaluate_script(&js);
             }


### PR DESCRIPTION
## Summary

`escape_for_js` gates all data flowing from the agent/tools into `evaluate_script('...')` JS string literals. It escaped `\`, `'`, `\n`, `\r` but missed three characters that also break JS single-quoted string literals:

| Character | Name | Why it breaks JS strings |
|-----------|------|--------------------------|
| `\u2028` | LINE SEPARATOR | JS line terminator per ECMAScript spec |
| `\u2029` | PARAGRAPH SEPARATOR | JS line terminator per ECMAScript spec |
| `\0` | NULL | Can truncate strings in some JS engines |

## What changed

1. **`escape_for_js`** — added `.replace` for `\0`, `\u{2028}`, `\u{2029}`
2. **`SendInitialState` handler** — replaced inline `.replace(...)` with `escape_for_js()` call for consistency (the inline version also missed `\n`/`\r`)

## Impact

Without this fix, a malicious or buggy MCP server returning tool output containing `\u2028` could break the JS string literal and potentially inject JavaScript into the webview context. The webview has IPC access to send chat input, approve tool calls, and change settings.

Practical exploitation requires a trusted MCP server to inject these specific Unicode characters — narrow attack surface but real.

## Testing

Verified with a JS string validator that:
- Before fix: `\u2028`/`\u2029`/`\0` pass through raw → JS string breaks → injection possible
- After fix: characters are escaped → JS string stays intact → injection blocked
- Normal inputs (quotes, newlines, backslashes) continue to work correctly