### PR TITLE
Fix download link in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Three tabs, one binary — captured from a live thClaws session looking at its o
 
 ### Pre-built binaries
 
-Download the latest release for your platform from the [Releases page](https://github.com/thClaws/thClaws/releases) or from [thclaws.ai/downloads](https://thclaws.ai/downloads).
-
+Download the latest release for your platform from the [Releases page](https://github.com/thClaws/thClaws/releases) or from [thclaws.ai/downloads](https://thclaws.ai/downloads.html). 
+ 
 Supported: macOS (Apple Silicon & Intel), Windows (x86_64 & ARM64), Linux (x86_64 & ARM64).
 
 ### Build from source


### PR DESCRIPTION
Updated the download link for the latest release to include the correct link.

## Summary

Fix download link in installation instructions

## Motivation

The current link is broken (หรือ outdated), which prevents users from downloading the correct version.

## Changes
- Updated the download URL in `README.md` from [https://thclaws.ai/downloads] to [https://thclaws.ai/downloads.html]

## Test plan

N/A

## Screenshots / recordings

N/A

## Checklist

N/A