### PR TITLE
fix: sync Cargo.lock to thclaws-core 0.7.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3948,7 +3948,7 @@ dependencies = [
 
 [[package]]
 name = "thclaws-core"
-version = "0.7.5"
+version = "0.7.7"
 dependencies = [
  "arboard",
  "async-stream",


### PR DESCRIPTION
## Summary

The v0.7.5 release left `Cargo.lock` at version `0.7.5` while `crates/core/Cargo.toml` advanced through `0.7.6` and `0.7.7`. Running `cargo build` or `cargo check` on a fresh checkout produces an unwanted lockfile diff that confuses contributors who expect a clean working tree after a build.

This PR bumps the lockfile entry for `thclaws-core` to `0.7.7` so the working tree stays clean after a build against the latest release.

## Test plan

- [x] `cargo check` produces no `Cargo.lock` diff
- [x] `git status` shows clean working tree after build

(Originally opened against 0.7.6; rebumped to 0.7.7 after the v0.7.7 release. Authorship preserved.)