### PR TITLE
add support for direct NVIDIA models

### DIFF
--- a/crates/core/resources/model_catalogue.json
+++ b/crates/core/resources/model_catalogue.json
@@ -24,6 +24,43 @@
         }
       }
     },
+    "nvidia": {
+      "list_url": "https://integrate.api.nvidia.com/v1/models",
+      "default_context": 131072,
+      "models": {
+        "nvidia/nemotron-3-super-120b-a12b": {
+          "context": 262144,
+          "source": "https://build.nvidia.com/nvidia/nemotron-3-super-120b-a12b",
+          "verified_at": "2026-05-04"
+        },
+        "nvidia/nemotron-3-nano-30b-a3b": {
+          "context": 262144,
+          "source": "https://build.nvidia.com/nvidia/nemotron-3-nano-30b-a3b",
+          "verified_at": "2026-05-04"
+        },
+        "nvidia/llama-3.1-nemotron-70b-instruct": {
+          "context": 131072,
+          "max_output": 16384,
+          "source": "https://build.nvidia.com/nvidia/llama-3_1-nemotron-70b-instruct",
+          "verified_at": "2026-05-04"
+        },
+        "nvidia/llama-3.3-nemotron-super-49b-v1.5": {
+          "context": 131072,
+          "source": "https://build.nvidia.com/nvidia/llama-3_3-nemotron-super-49b-v1-5",
+          "verified_at": "2026-05-04"
+        },
+        "nvidia/nemotron-nano-9b-v2": {
+          "context": 131072,
+          "source": "https://build.nvidia.com/nvidia/nemotron-nano-9b-v2",
+          "verified_at": "2026-05-04"
+        },
+        "nvidia/nemotron-nano-12b-v2-vl": {
+          "context": 131072,
+          "source": "https://build.nvidia.com/nvidia/nemotron-nano-12b-v2-vl",
+          "verified_at": "2026-05-04"
+        }
+      }
+    },
     "deepseek": {
       "list_url": "https://api.deepseek.com/v1/models",
       "default_context": 131072,

--- a/crates/core/src/bin/catalogue_seed.rs
+++ b/crates/core/src/bin/catalogue_seed.rs
@@ -37,6 +37,7 @@ const GEMINI_URL: &str = "https://generativelanguage.googleapis.com/v1beta/model
 const OLLAMA_CLOUD_URL: &str = "https://ollama.com/v1/models";
 const DEEPSEEK_URL: &str = "https://api.deepseek.com/v1/models";
 const THAILLM_URL: &str = "http://thaillm.or.th/api/v1/models";
+const NVIDIA_URL: &str = "https://integrate.api.nvidia.com/v1/models";
 const DEFAULT_TARGET: &str = "crates/core/resources/model_catalogue.json";
 
 // ── Wire types ──────────────────────────────────────────────────────
@@ -340,6 +341,40 @@ async fn run() -> Result<String, String> {
         }
     } else {
         report.push("  thaillm:     skipped (no THAILLM_API_KEY)".into());
+    }
+
+    // 4d. NVIDIA NIM — OpenAI-compatible `/v1/models` at
+    //     integrate.api.nvidia.com. Model IDs are already namespaced
+    //     with the `nvidia/` prefix by NVIDIA's own API (e.g.
+    //     `nvidia/nemotron-3-super-120b-a12b`), so no prefix is added
+    //     on our side — different from ThaiLLM / Ollama Cloud where bare
+    //     ids need a routing prefix appended. Context comes from
+    //     OpenRouter's mirror of the same models where available;
+    //     falls back to provider default (131072).
+    if let Ok(key) = std::env::var("NVIDIA_API_KEY") {
+        match fetch_nvidia(&key).await {
+            Ok(ids) => {
+                let pc = cat
+                    .providers
+                    .entry("nvidia".into())
+                    .or_insert_with(ProviderCatalogue::default);
+                if pc.default_context.is_none() {
+                    pc.default_context = Some(131072);
+                }
+                let added = merge_discovered(
+                    &mut cat,
+                    "nvidia",
+                    NVIDIA_URL,
+                    ids,
+                    &openrouter_ctx_by_bare,
+                    &today,
+                );
+                push_provider_stats(&mut report, "nvidia", &added, None);
+            }
+            Err(e) => report.push(format!("  nvidia:      FAILED ({e})")),
+        }
+    } else {
+        report.push("  nvidia:      skipped (no NVIDIA_API_KEY)".into());
     }
 
     // 5. Derive agent-sdk rows from anthropic. The Claude CLI subprocess
@@ -680,6 +715,24 @@ async fn fetch_thaillm(key: &str) -> Result<Vec<String>, String> {
         .map_err(|e| format!("GET {THAILLM_URL}: {e}"))?;
     if !resp.status().is_success() {
         return Err(format!("thaillm HTTP {}", resp.status()));
+    }
+    let env: OpenAIEnvelope = resp.json().await.map_err(|e| format!("json: {e}"))?;
+    Ok(env.data.into_iter().map(|m| m.id).collect())
+}
+
+/// Fetch the NVIDIA NIM model list. The endpoint is OpenAI-compatible —
+/// `/v1/models` returns `{data:[{id,...}]}`. Model IDs already include
+/// the `nvidia/` owner prefix (e.g. `nvidia/nemotron-3-super-120b-a12b`),
+/// so no additional prefix is applied by the caller.
+async fn fetch_nvidia(key: &str) -> Result<Vec<String>, String> {
+    let resp = client()?
+        .get(NVIDIA_URL)
+        .bearer_auth(key)
+        .send()
+        .await
+        .map_err(|e| format!("GET {NVIDIA_URL}: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("nvidia HTTP {}", resp.status()));
     }
     let env: OpenAIEnvelope = resp.json().await.map_err(|e| format!("json: {e}"))?;
     Ok(env.data.into_iter().map(|m| m.id).collect())

--- a/crates/core/src/model_catalogue.rs
+++ b/crates/core/src/model_catalogue.rs
@@ -592,6 +592,7 @@ pub fn provider_kind_name(k: crate::providers::ProviderKind) -> &'static str {
         ProviderKind::OpenAICompat => "openai-compat",
         ProviderKind::DeepSeek => "deepseek",
         ProviderKind::ThaiLLM => "thaillm",
+        ProviderKind::Nvidia => "nvidia",
     }
 }
 

--- a/crates/core/src/providers/mod.rs
+++ b/crates/core/src/providers/mod.rs
@@ -40,6 +40,7 @@ pub enum ProviderKind {
     OpenAICompat,
     DeepSeek,
     ThaiLLM,
+    Nvidia,
 }
 
 impl ProviderKind {
@@ -61,6 +62,7 @@ impl ProviderKind {
         Self::OpenAICompat,
         Self::DeepSeek,
         Self::ThaiLLM,
+        Self::Nvidia,
     ];
 
     pub fn name(&self) -> &'static str {
@@ -82,6 +84,7 @@ impl ProviderKind {
             Self::OpenAICompat => "openai-compat",
             Self::DeepSeek => "deepseek",
             Self::ThaiLLM => "thaillm",
+            Self::Nvidia => "nvidia",
         }
     }
 
@@ -134,6 +137,10 @@ impl ProviderKind {
             // bare model id. OpenThaiGPT v7.2 is the most general-purpose
             // default; users can `/model thaillm/<other>` to switch.
             Self::ThaiLLM => "thaillm/OpenThaiGPT-ThaiLLM-8B-Instruct-v7.2",
+            // NVIDIA NIM — OpenAI-compatible hosted inference at integrate.api.nvidia.com.
+            // Model IDs keep the `nvidia/` prefix on the wire (that's NVIDIA's own namespace,
+            // not a thClaws routing prefix). Override via NVIDIA_BASE_URL for on-prem NIM.
+            Self::Nvidia => "nvidia/nemotron-3-super-120b-a12b",
         }
     }
 
@@ -153,6 +160,7 @@ impl ProviderKind {
             Self::OpenAICompat => Some("OPENAI_COMPAT_BASE_URL"),
             Self::DeepSeek => Some("DEEPSEEK_BASE_URL"),
             Self::ThaiLLM => Some("THAILLM_BASE_URL"),
+            Self::Nvidia => Some("NVIDIA_BASE_URL"),
             _ => None,
         }
     }
@@ -197,6 +205,7 @@ impl ProviderKind {
             Self::OpenAICompat => Some("http://localhost:8000/v1"),
             Self::DeepSeek => Some("https://api.deepseek.com/v1"),
             Self::ThaiLLM => Some("http://thaillm.or.th/api/v1"),
+            Self::Nvidia => Some("https://integrate.api.nvidia.com/v1"),
             _ => None,
         }
     }
@@ -221,6 +230,7 @@ impl ProviderKind {
             Self::OpenAICompat => Some("OPENAI_COMPAT_API_KEY"),
             Self::DeepSeek => Some("DEEPSEEK_API_KEY"),
             Self::ThaiLLM => Some("THAILLM_API_KEY"),
+            Self::Nvidia => Some("NVIDIA_API_KEY"),
         }
     }
 
@@ -318,7 +328,8 @@ impl ProviderKind {
             | Self::LMStudio
             | Self::AzureAIFoundry
             | Self::OpenAICompat
-            | Self::DeepSeek => None,
+            | Self::DeepSeek
+            | Self::Nvidia => None,
         }
     }
 
@@ -388,6 +399,13 @@ impl ProviderKind {
             Some(Self::OllamaCloud)
         } else if model.starts_with("azure/") {
             Some(Self::AzureAIFoundry)
+        } else if model.starts_with("nvidia/") {
+            // NVIDIA NIM (integrate.api.nvidia.com). Model IDs like
+            // `nvidia/nemotron-3-super-120b-a12b` keep the `nvidia/` prefix
+            // on the wire — it is part of the upstream model ID, not stripped.
+            // OpenRouter proxies the same models as `openrouter/nvidia/...`;
+            // the `openrouter/` check above catches those first.
+            Some(Self::Nvidia)
         } else {
             None
         }

--- a/crates/core/src/repl.rs
+++ b/crates/core/src/repl.rs
@@ -2088,6 +2088,22 @@ pub fn build_provider(config: &AppConfig) -> Result<Arc<dyn Provider>> {
                     .with_strip_model_prefix("thaillm/"),
             ))
         }
+        ProviderKind::Nvidia => {
+            // NVIDIA NIM — OpenAI-compatible hosted inference at
+            // integrate.api.nvidia.com. Model IDs (e.g.
+            // `nvidia/nemotron-3-super-120b-a12b`) keep the `nvidia/`
+            // prefix on the wire — it is part of NVIDIA's own model
+            // namespace, not a thClaws routing prefix. Override via
+            // NVIDIA_BASE_URL for on-prem NIM deployments.
+            let base = std::env::var("NVIDIA_BASE_URL")
+                .unwrap_or_else(|_| "https://integrate.api.nvidia.com/v1".to_string());
+            let url = if base.ends_with("/chat/completions") {
+                base
+            } else {
+                format!("{}/chat/completions", base.trim_end_matches('/'))
+            };
+            Ok(Arc::new(OpenAIProvider::new(api_key).with_base_url(url)))
+        }
         ProviderKind::Ollama
         | ProviderKind::OllamaAnthropic
         | ProviderKind::LMStudio


### PR DESCRIPTION
## Summary

This PR add a new 'nvidia' provider intended to support direct NVIDIA models hosted locally. In the meantime, users can test by set NVIDIA_BASE_URL to https://integrate.api.nvidia.com/v1.  Then request NVIDIA_API_KEY from https://build.nvidia.com.

## Motivation

For users/organizations who concern about data privacy and security. Running local models are a good choice due to there is no data sent outside organization.

## Changes
  - modified:   crates/core/resources/model_catalogue.json
  - modified:   crates/core/src/bin/catalogue_seed.rs
  - modified:   crates/core/src/model_catalogue.rs
  - modified:   crates/core/src/providers/mod.rs
  - modified:   crates/core/src/repl.rs

## Test plan

How did you verify this works?

- [ PASSED] `cargo test --features gui` passes locally
- [ PASSED] `cargo fmt --check` ` passes
- [No-CHANG] Frontend type-check passes (`cd frontend && pnpm tsc --noEmit`) — if frontend touched
- [ ] Manually exercised the feature — steps:
  1. switch provider to 'nvidia'
  2. switch model to 'nvidia/nemotron-3-super-120b-a12b'
  3. test sending prompts to the LLM, then the response have been returned as expected.

## Screenshots / recordings

For GUI / CLI UX changes, include a before / after screenshot or short recording.
<img width="934" height="244" alt="image" src="https://github.com/user-attachments/assets/cbe60a3b-7399-49f0-bb40-f1e24d73cb1e" />

<img width="603" height="406" alt="image" src="https://github.com/user-attachments/assets/133261e9-bbdb-4630-a897-ee6263acdea5" />



## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if behavior changes (README / CHANGELOG / in-repo docs)
- [ ] No new compiler warnings introduced
- [ ] PR scope is focused — no unrelated changes
- [ ] Commits follow project style (concise, imperative, optional `feat/fix/docs/...` prefix)
- [ ] 