### PR TITLE
fix: preserve Gemini thoughtSignature in function calling

### DIFF
--- a/crates/core/src/agent.rs
+++ b/crates/core/src/agent.rs
@@ -1011,6 +1011,7 @@ impl Agent {
                                 id: id.clone(),
                                 name: name.clone(),
                                 input: serde_json::json!({}),
+                                thought_signature: None,
                             };
                             yield AgentEvent::ToolCallStart {
                                 id: id.clone(),
@@ -1038,7 +1039,7 @@ impl Agent {
                             // emit ToolCallDenied / ToolCallResult as
                             // before, so UI consumers don't get orphaned
                             // ToolCallStart events.
-                            if let ContentBlock::ToolUse { id, name, input } = &block {
+                            if let ContentBlock::ToolUse { id, name, input, .. } = &block {
                                 yield AgentEvent::ToolCallStart {
                                     id: id.clone(),
                                     name: name.clone(),
@@ -1107,7 +1108,7 @@ impl Agent {
                 // Execute each tool (after approval, if required) and collect results.
                 let mut result_blocks: Vec<ContentBlock> = Vec::new();
                 for tu in &turn_tool_uses {
-                    let ContentBlock::ToolUse { id, name, input } = tu else { continue };
+                    let ContentBlock::ToolUse { id, name, input, .. } = tu else { continue };
 
                     // L4 (M6.17): if this tool's JSON input failed to
                     // parse during assembly, short-circuit with a
@@ -2261,6 +2262,7 @@ mod tests {
             ProviderEvent::ToolUseStart {
                 id: id.into(),
                 name: name.into(),
+                thought_signature: None,
             },
             ProviderEvent::ToolUseDelta {
                 partial_json: args_json.into(),

--- a/crates/core/src/compaction.rs
+++ b/crates/core/src/compaction.rs
@@ -617,6 +617,7 @@ mod tests {
                 id: id.into(),
                 name: name.into(),
                 input: serde_json::json!({}),
+                thought_signature: None,
             }],
         }
     }

--- a/crates/core/src/providers/anthropic.rs
+++ b/crates/core/src/providers/anthropic.rs
@@ -369,7 +369,11 @@ pub fn parse_sse_event(raw: &str) -> Result<Option<ProviderEvent>> {
                         .and_then(Value::as_str)
                         .unwrap_or_default()
                         .to_string();
-                    Some(ProviderEvent::ToolUseStart { id, name })
+                    Some(ProviderEvent::ToolUseStart {
+                        id,
+                        name,
+                        thought_signature: None,
+                    })
                 }
                 _ => None,
             }
@@ -459,7 +463,8 @@ mod tests {
             ev,
             ProviderEvent::ToolUseStart {
                 id: "toolu_abc".into(),
-                name: "read_file".into()
+                name: "read_file".into(),
+                thought_signature: None,
             }
         );
     }
@@ -794,7 +799,10 @@ mod tests {
 
         assert_eq!(result.text, "I'll read that file.");
         assert_eq!(result.tool_uses.len(), 1);
-        if let ContentBlock::ToolUse { id, name, input } = &result.tool_uses[0] {
+        if let ContentBlock::ToolUse {
+            id, name, input, ..
+        } = &result.tool_uses[0]
+        {
             assert_eq!(id, "toolu_01A");
             assert_eq!(name, "read_file");
             assert_eq!(input, &serde_json::json!({"path": "/tmp/x"}));
@@ -937,6 +945,7 @@ mod tests {
             id: "toolu_x".into(),
             name: "Read".into(),
             input: serde_json::json!({"path": "/tmp"}),
+            thought_signature: None,
         });
         let body = AnthropicProvider::build_body(&req);
         let last = body["messages"][1]["content"]

--- a/crates/core/src/providers/assemble.rs
+++ b/crates/core/src/providers/assemble.rs
@@ -61,6 +61,7 @@ enum BlockState {
         id: String,
         name: String,
         buf: String,
+        thought_signature: Option<String>,
     },
 }
 
@@ -248,11 +249,12 @@ where
                     think.in_block = false;
                     yield AssembledEvent::Thinking(s);
                 }
-                ProviderEvent::ToolUseStart { id, name } => {
+                ProviderEvent::ToolUseStart { id, name, thought_signature } => {
                     state = BlockState::ToolUse {
                         id,
                         name,
                         buf: String::new(),
+                        thought_signature,
                     };
                 }
                 ProviderEvent::ToolUseDelta { partial_json } => {
@@ -262,12 +264,13 @@ where
                 }
                 ProviderEvent::ContentBlockStop => {
                     let prev = std::mem::replace(&mut state, BlockState::None);
-                    if let BlockState::ToolUse { id, name, buf } = prev {
+                    if let BlockState::ToolUse { id, name, buf, thought_signature } = prev {
                         if buf.trim().is_empty() {
                             yield AssembledEvent::ToolUse(ContentBlock::ToolUse {
                                 id,
                                 name,
                                 input: serde_json::json!({}),
+                                thought_signature,
                             });
                         } else {
                             match serde_json::from_str::<serde_json::Value>(&buf) {
@@ -276,6 +279,7 @@ where
                                         id,
                                         name,
                                         input,
+                                        thought_signature,
                                     });
                                 }
                                 Err(e) => {
@@ -327,6 +331,7 @@ where
                     id,
                     name,
                     input: serde_json::json!({}),
+                    thought_signature: None,
                 });
             }
             AssembledEvent::Done { stop_reason, usage } => {
@@ -450,6 +455,7 @@ mod tests {
             ProviderEvent::ToolUseStart {
                 id: "toolu_1".into(),
                 name: "read_file".into(),
+                thought_signature: None,
             },
             ProviderEvent::ToolUseDelta {
                 partial_json: "{\"pa".into(),
@@ -471,7 +477,9 @@ mod tests {
         assert_eq!(r.text, "");
         assert_eq!(r.tool_uses.len(), 1);
         match &r.tool_uses[0] {
-            ContentBlock::ToolUse { id, name, input } => {
+            ContentBlock::ToolUse {
+                id, name, input, ..
+            } => {
                 assert_eq!(id, "toolu_1");
                 assert_eq!(name, "read_file");
                 assert_eq!(input, &serde_json::json!({"path": "/tmp/x"}));
@@ -490,6 +498,7 @@ mod tests {
             ProviderEvent::ToolUseStart {
                 id: "toolu_2".into(),
                 name: "glob".into(),
+                thought_signature: None,
             },
             ProviderEvent::ToolUseDelta {
                 partial_json: "{\"pattern\":\"*.rs\"}".into(),
@@ -518,6 +527,7 @@ mod tests {
             ProviderEvent::ToolUseStart {
                 id: "a".into(),
                 name: "read".into(),
+                thought_signature: None,
             },
             ProviderEvent::ToolUseDelta {
                 partial_json: "{\"p\":1}".into(),
@@ -526,6 +536,7 @@ mod tests {
             ProviderEvent::ToolUseStart {
                 id: "b".into(),
                 name: "write".into(),
+                thought_signature: None,
             },
             ProviderEvent::ToolUseDelta {
                 partial_json: "{\"p\":2}".into(),
@@ -556,6 +567,7 @@ mod tests {
             ProviderEvent::ToolUseStart {
                 id: "x".into(),
                 name: "list_projects".into(),
+                thought_signature: None,
             },
             ProviderEvent::ContentBlockStop,
             ProviderEvent::MessageStop {
@@ -718,6 +730,7 @@ mod tests {
             ProviderEvent::ToolUseStart {
                 id: "x".into(),
                 name: "t".into(),
+                thought_signature: None,
             },
             ProviderEvent::ToolUseDelta {
                 partial_json: "{not-json".into(),
@@ -728,7 +741,10 @@ mod tests {
         .expect("collect_turn should succeed; parse failure is in-band now");
         assert_eq!(result.tool_uses.len(), 1, "synthetic ToolUse expected");
         // Synthetic block has empty input.
-        if let ContentBlock::ToolUse { id, name, input } = &result.tool_uses[0] {
+        if let ContentBlock::ToolUse {
+            id, name, input, ..
+        } = &result.tool_uses[0]
+        {
             assert_eq!(id, "x");
             assert_eq!(name, "t");
             assert_eq!(input, &serde_json::json!({}));

--- a/crates/core/src/providers/gemini.rs
+++ b/crates/core/src/providers/gemini.rs
@@ -160,10 +160,19 @@ impl GeminiProvider {
                             }
                         }));
                     }
-                    ContentBlock::ToolUse { name, input, .. } => {
-                        parts.push(json!({
+                    ContentBlock::ToolUse {
+                        name,
+                        input,
+                        thought_signature,
+                        ..
+                    } => {
+                        let mut fc = json!({
                             "functionCall": { "name": name, "args": input }
-                        }));
+                        });
+                        if let Some(sig) = thought_signature {
+                            fc["thoughtSignature"] = json!(sig);
+                        }
+                        parts.push(fc);
                     }
                     ContentBlock::ToolResult {
                         tool_use_id,
@@ -521,7 +530,15 @@ pub fn parse_sse_event(raw: &str, state: &mut ParseState) -> Result<Vec<Provider
                 // turns.
                 let counter_value = state.next_tool_id.fetch_add(1, Ordering::Relaxed);
                 let id = format!("gemini-call-{counter_value}");
-                out.push(ProviderEvent::ToolUseStart { id, name });
+                let thought_signature = part
+                    .get("thoughtSignature")
+                    .and_then(Value::as_str)
+                    .map(String::from);
+                out.push(ProviderEvent::ToolUseStart {
+                    id,
+                    name,
+                    thought_signature,
+                });
                 out.push(ProviderEvent::ToolUseDelta {
                     partial_json: args.to_string(),
                 });
@@ -838,6 +855,7 @@ mod tests {
             ProviderEvent::ToolUseStart {
                 id: "gemini-call-0".into(),
                 name: "Read".into(),
+                thought_signature: None,
             }
         );
         match &events[2] {
@@ -871,6 +889,7 @@ mod tests {
                         id: "t1".into(),
                         name: "Read".into(),
                         input: json!({"path": "/x"}),
+                        thought_signature: None,
                     }],
                 },
                 crate::types::Message {
@@ -921,6 +940,7 @@ mod tests {
                         id: "t2".into(),
                         name: "Read".into(),
                         input: json!({"path": "/tmp/x.png"}),
+                        thought_signature: None,
                     }],
                 },
                 crate::types::Message {
@@ -1020,6 +1040,7 @@ mod tests {
                         id: "t3".into(),
                         name: "Bash".into(),
                         input: json!({"cmd": "ls"}),
+                        thought_signature: None,
                     }],
                 },
                 crate::types::Message {

--- a/crates/core/src/providers/mod.rs
+++ b/crates/core/src/providers/mod.rs
@@ -576,6 +576,7 @@ pub enum ProviderEvent {
     ToolUseStart {
         id: String,
         name: String,
+        thought_signature: Option<String>,
     },
     ToolUseDelta {
         partial_json: String,

--- a/crates/core/src/providers/ollama.rs
+++ b/crates/core/src/providers/ollama.rs
@@ -452,7 +452,11 @@ pub fn parse_line(line: &str, state: &mut ParseState) -> Result<Vec<ProviderEven
                 })
                 .unwrap_or_else(|| "{}".to_string());
 
-            out.push(ProviderEvent::ToolUseStart { id, name });
+            out.push(ProviderEvent::ToolUseStart {
+                id,
+                name,
+                thought_signature: None,
+            });
             if !args_json.is_empty() {
                 out.push(ProviderEvent::ToolUseDelta {
                     partial_json: args_json,
@@ -475,6 +479,7 @@ pub fn parse_line(line: &str, state: &mut ParseState) -> Result<Vec<ProviderEven
                 out.push(ProviderEvent::ToolUseStart {
                     id: "ollama-leaked-call".into(),
                     name,
+                    thought_signature: None,
                 });
                 out.push(ProviderEvent::ToolUseDelta {
                     partial_json: args_json,
@@ -579,6 +584,7 @@ mod tests {
             ProviderEvent::ToolUseStart {
                 id: "ollama-leaked-call".into(),
                 name: "Write".into(),
+                thought_signature: None,
             }
         );
         match &events[2] {
@@ -611,6 +617,7 @@ mod tests {
             ProviderEvent::ToolUseStart {
                 id: "ollama-leaked-call".into(),
                 name: "Read".into(),
+                thought_signature: None,
             }
         );
     }
@@ -679,6 +686,7 @@ mod tests {
             ProviderEvent::ToolUseStart {
                 id: "ollama-call-0".into(),
                 name: "Read".into(),
+                thought_signature: None,
             }
         );
         match &events[2] {
@@ -711,6 +719,7 @@ mod tests {
                         id: "t1".into(),
                         name: "Read".into(),
                         input: json!({"path": "/x"}),
+                        thought_signature: None,
                     }],
                 },
                 crate::types::Message {

--- a/crates/core/src/providers/openai.rs
+++ b/crates/core/src/providers/openai.rs
@@ -148,7 +148,9 @@ impl OpenAIProvider {
                     } => {
                         inline_user_images.push((media_type.clone(), data.clone()));
                     }
-                    ContentBlock::ToolUse { id, name, input } => {
+                    ContentBlock::ToolUse {
+                        id, name, input, ..
+                    } => {
                         let args = serde_json::to_string(input).unwrap_or_else(|_| "{}".into());
                         tool_calls.push(json!({
                             "id": id,
@@ -618,7 +620,11 @@ pub fn parse_chunk(raw: &str, state: &mut ParseState) -> Result<Vec<ProviderEven
                         .and_then(Value::as_str)
                         .unwrap_or("")
                         .to_string();
-                    out.push(ProviderEvent::ToolUseStart { id, name });
+                    out.push(ProviderEvent::ToolUseStart {
+                        id,
+                        name,
+                        thought_signature: None,
+                    });
                 }
 
                 if let Some(args) = func
@@ -894,7 +900,8 @@ mod tests {
             events[1],
             ProviderEvent::ToolUseStart {
                 id: "call_abc".into(),
-                name: "read_file".into()
+                name: "read_file".into(),
+                thought_signature: None,
             }
         );
         assert_eq!(
@@ -933,7 +940,8 @@ mod tests {
             events[1],
             ProviderEvent::ToolUseStart {
                 id: "a".into(),
-                name: "r".into()
+                name: "r".into(),
+                thought_signature: None,
             }
         );
         assert_eq!(
@@ -947,7 +955,8 @@ mod tests {
             events[4],
             ProviderEvent::ToolUseStart {
                 id: "b".into(),
-                name: "w".into()
+                name: "w".into(),
+                thought_signature: None,
             }
         );
         assert_eq!(
@@ -980,6 +989,7 @@ mod tests {
                         id: "call_1".into(),
                         name: "read".into(),
                         input: json!({"path": "/a"}),
+                        thought_signature: None,
                     }],
                 },
                 Message {
@@ -1032,6 +1042,7 @@ mod tests {
                         id: "call_2".into(),
                         name: "Read".into(),
                         input: json!({"path": "/tmp/x.png"}),
+                        thought_signature: None,
                     }],
                 },
                 Message {
@@ -1117,16 +1128,19 @@ mod tests {
                             id: "call_a".into(),
                             name: "Read".into(),
                             input: json!({"path": "/tmp/a.png"}),
+                            thought_signature: None,
                         },
                         ContentBlock::ToolUse {
                             id: "call_b".into(),
                             name: "Read".into(),
                             input: json!({"path": "/tmp/b.png"}),
+                            thought_signature: None,
                         },
                         ContentBlock::ToolUse {
                             id: "call_c".into(),
                             name: "Read".into(),
                             input: json!({"path": "/tmp/c.png"}),
+                            thought_signature: None,
                         },
                     ],
                 },
@@ -1291,6 +1305,7 @@ mod tests {
                         id: "call_3".into(),
                         name: "Bash".into(),
                         input: json!({"cmd": "ls"}),
+                        thought_signature: None,
                     }],
                 },
                 Message {
@@ -1447,7 +1462,10 @@ mod tests {
 
         assert_eq!(result.text, "");
         assert_eq!(result.tool_uses.len(), 1);
-        if let ContentBlock::ToolUse { id, name, input } = &result.tool_uses[0] {
+        if let ContentBlock::ToolUse {
+            id, name, input, ..
+        } = &result.tool_uses[0]
+        {
             assert_eq!(id, "call_abc");
             assert_eq!(name, "read_file");
             assert_eq!(input, &json!({"path": "/tmp/x"}));

--- a/crates/core/src/providers/openai_responses.rs
+++ b/crates/core/src/providers/openai_responses.rs
@@ -85,7 +85,9 @@ impl OpenAIResponsesProvider {
                     // future turn against a vision-capable provider
                     // still sees it).
                     ContentBlock::Image { .. } => {}
-                    ContentBlock::ToolUse { id, name, input } => {
+                    ContentBlock::ToolUse {
+                        id, name, input, ..
+                    } => {
                         out.push(json!({
                             "type": "function_call",
                             "call_id": id,
@@ -362,7 +364,11 @@ fn parse_response_event(
                         .and_then(Value::as_str)
                         .unwrap_or("")
                         .to_string();
-                    out.push(ProviderEvent::ToolUseStart { id, name });
+                    out.push(ProviderEvent::ToolUseStart {
+                        id,
+                        name,
+                        thought_signature: None,
+                    });
                 }
             }
         }
@@ -502,7 +508,8 @@ mod tests {
             events[1],
             ProviderEvent::ToolUseStart {
                 id: "call_1".into(),
-                name: "Read".into()
+                name: "Read".into(),
+                thought_signature: None,
             }
         );
         assert!(matches!(events[2], ProviderEvent::ToolUseDelta { .. }));

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -42,6 +42,8 @@ pub enum ContentBlock {
         id: String,
         name: String,
         input: serde_json::Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        thought_signature: Option<String>,
     },
     ToolResult {
         tool_use_id: String,
@@ -199,6 +201,7 @@ mod tests {
             id: "toolu_1".into(),
             name: "read_file".into(),
             input: serde_json::json!({"path": "/tmp/x"}),
+            thought_signature: None,
         };
         let j = serde_json::to_value(&block).unwrap();
         assert_eq!(


### PR DESCRIPTION
## Summary

Gemini 3+ models require `thoughtSignature` to be passed back in conversation history during function calling. Without it, the API returns HTTP 400:

```
Function call is missing a thought_signature in functionCall parts.
```

## Changes

- Added `thought_signature: Option<String>` to `ContentBlock::ToolUse` and `ProviderEvent::ToolUseStart`
- Parse `thoughtSignature` from Gemini response `part` (sibling of `functionCall`, not nested inside it)
- Echo it back at the part level in `messages_to_gemini()`
- Thread the signature through `BlockState::ToolUse` in `assemble.rs`
- All non-Gemini providers pass `thought_signature: None`

## Testing

- `cargo fmt --check` ✅
- `cargo test --features gui` ✅ (all tests pass)
- Manual test: Gemini 2.5 Flash function calling works correctly

## References

- Closes #65
- [Google docs: Thought Signatures](https://ai.google.dev/gemini-api/docs/thought-signatures)
- Gemini 3: signature is **mandatory** (400 if missing)
- Gemini 2.5: signature is **optional** but recommended