### PR TITLE
fix: enable Cmd+C copy for non-input text selection in GUI

### DIFF
--- a/frontend/src/hooks/useEditingShortcuts.ts
+++ b/frontend/src/hooks/useEditingShortcuts.ts
@@ -27,11 +27,22 @@ export function useEditingShortcuts() {
       if (!target) return;
       const tag = target.tagName;
       const isInput = tag === "INPUT" || tag === "TEXTAREA";
+
+      const key = e.key.toLowerCase();
+
+      // Handle Cmd+C for any text selection (not just input/textarea)
+      if (key === "c" && !e.shiftKey && !isInput) {
+        const sel = window.getSelection();
+        if (sel && sel.toString().length > 0) {
+          e.preventDefault();
+          send({ type: "clipboard_write", text: sel.toString() });
+        }
+        return;
+      }
+
       if (!isInput) return;
       const field = target as HTMLInputElement | HTMLTextAreaElement;
       if (field.disabled || field.readOnly) return;
-
-      const key = e.key.toLowerCase();
 
       if (key === "v" && !e.shiftKey) {
         e.preventDefault();


### PR DESCRIPTION
## Summary

`Cmd+C` does not copy selected text in the GUI mode on macOS when selecting text in chat messages or other non-input elements.

## Root cause

`useEditingShortcuts` only handles `Cmd+C` for `<input>` and `<textarea>` elements. Text in chat messages lives in `<div>` elements, so the shortcut is never intercepted — and since wry blocks `navigator.clipboard`, native copy doesn't work either.

## Fix

Added a `window.getSelection()` check before the `isInput` guard. If there's any text selection in the DOM, send it to the native clipboard via the existing `clipboard_write` IPC bridge.

## Testing

- Select text in chat messages → `Cmd+C` → paste elsewhere ✅
- Input/textarea copy still works as before ✅
- No regressions in paste (`Cmd+V`) or cut (`Cmd+X`) behavior

Closes #70