### PR TITLE
docs(readme): sync provider list with current ProviderKind registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The same `Agent` loop, `Session`, and `ToolRegistry` back every UX:
 
 ## What makes it different
 
-- **Multi-provider.** Anthropic, OpenAI, Gemini, Alibaba DashScope, OpenRouter, Ollama (local and Anthropic-compatible), Agentic Press, plus a generic **OpenAI-compatible** slot (`oai/*`) for LiteLLM / Portkey / Helicone / vLLM / internal proxies — auto-detected by model name prefix. Switch mid-session with `/model` or swap the whole provider with `/provider`.
+- **Multi-provider.** Anthropic (native + Claude Agent SDK via Claude Code auth), OpenAI (Chat Completions + Responses/Codex), Google Gemini & Gemma, Alibaba DashScope (Qwen), DeepSeek, Z.ai (GLM Coding Plan), NVIDIA NIM, NSTDA Thai LLM (OpenThaiGPT, Typhoon, Pathumma, THaLLE), OpenRouter, Agentic Press, Azure AI Foundry, Ollama (local, local Anthropic-compatible, and Ollama Cloud), LMStudio, plus a generic **OpenAI-compatible** slot (`oai/*`) for LiteLLM / Portkey / Helicone / vLLM / internal proxies — auto-detected by model name prefix. Switch mid-session with `/model` or swap the whole provider with `/provider`.
 
 - **Any knowledge worker, not just engineers.** Chat tab for researchers, PMs, ops, legal, marketing, finance — natural-language prompts, file access, knowledge-base lookup, drafting. Terminal tab for engineers who want the raw REPL. Same engine, same sessions, same config — different preferred surface.
 


### PR DESCRIPTION
## Summary

The "Multi-provider" bullet in `README.md` listed only a subset of the backends thClaws actually ships. This PR brings the README in line with the current `ProviderKind` registry in `crates/core/src/providers/mod.rs` so new contributors and users see an accurate inventory.

## Motivation

The README only mentioned Anthropic, OpenAI, Gemini, DashScope, OpenRouter, Ollama (local + Anthropic-compatible), Agentic Press, and the generic `oai/*` slot. Several providers have landed since (NVIDIA NIM via #67, ThaiLLM, DeepSeek, Z.ai, Azure AI Foundry, LMStudio, Ollama Cloud, OpenAI Responses/Codex, Anthropic Agent SDK, Gemma) but were not surfaced in the top-level feature list.

## Changes

- `README.md` — expand the **Multi-provider** bullet to cover every variant in `ProviderKind::ALL`:
  - Anthropic (native + Claude Agent SDK via Claude Code auth)
  - OpenAI (Chat Completions + Responses/Codex)
  - Google Gemini & Gemma
  - Alibaba DashScope (Qwen)
  - DeepSeek
  - Z.ai (GLM Coding Plan)
  - NVIDIA NIM
  - NSTDA Thai LLM (OpenThaiGPT, Typhoon, Pathumma, THaLLE)
  - OpenRouter
  - Agentic Press
  - Azure AI Foundry
  - Ollama (local, local Anthropic-compatible, and Ollama Cloud)
  - LMStudio
  - Generic OpenAI-compatible (`oai/*`) — unchanged
- Auto-detection note and `/model` / `/provider` mid-session switch hint preserved.

Docs-only — no source changes.

## Test plan

- [x] `cargo fmt --check` — N/A (no Rust changes)
- [x] `cargo test --features gui` — N/A (no Rust changes)
- [x] `cargo clippy --features gui -- -D warnings` — N/A (no Rust changes)
- [x] Frontend type-check — N/A (no frontend changes)
- [x] Visual diff verified against `crates/core/src/providers/mod.rs::ProviderKind::ALL` — every variant is represented in the README bullet.

## Checklist

- [x] PR scope is focused — README only, no unrelated changes
- [x] No new compiler warnings introduced
- [x] Commit follows project style (`docs(readme):` prefix matching prior README sync commits)