### PR TITLE
fix(mcp): show real tool counts in MCP Servers sidebar panel

### DIFF
--- a/crates/core/src/gui.rs
+++ b/crates/core/src/gui.rs
@@ -284,19 +284,40 @@ use crate::providers::{auto_fallback_model, provider_has_credentials};
 // instructions_path moved to crate::instructions in M6.36 SERVE9d.
 // instructions_path migrated; arms removed in SERVE9k.
 
+/// Per-server tool count, populated when `McpReady` fires in the worker loop.
+/// Keyed by server name; value is the number of tools the server exposed.
+static MCP_TOOL_COUNTS: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashMap<String, usize>>,
+> = std::sync::OnceLock::new();
+
+fn mcp_tool_counts() -> &'static std::sync::Mutex<std::collections::HashMap<String, usize>> {
+    MCP_TOOL_COUNTS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// Record the tool count for a connected MCP server. Called from the
+/// `McpReady` handler in `shared_session.rs` so `build_mcp_update_payload`
+/// can surface real counts instead of zeros.
+pub(crate) fn update_mcp_tool_count(server_name: &str, count: usize) {
+    if let Ok(mut map) = mcp_tool_counts().lock() {
+        map.insert(server_name.to_string(), count);
+    }
+}
+
 /// Build the `mcp_update` IPC payload: the configured MCP servers for
 /// this session (read fresh from disk so removals via `/mcp remove` are
-/// reflected immediately, not after a restart). Tool count is reported
-/// as 0 for now — the live registry doesn't track which tool came from
-/// which MCP server, so we'd have to hold a separate name-to-server
-/// map to do better. The sidebar today only renders the name, so 0 is
-/// a non-misleading placeholder.
+/// reflected immediately, not after a restart). Tool counts come from
+/// `MCP_TOOL_COUNTS`, which is updated by the `McpReady` worker event
+/// once each server successfully connects and lists its tools.
 pub(crate) fn build_mcp_update_payload() -> serde_json::Value {
     let config = crate::config::AppConfig::load().unwrap_or_default();
+    let counts = mcp_tool_counts().lock().unwrap_or_else(|e| e.into_inner());
     let servers: Vec<serde_json::Value> = config
         .mcp_servers
         .iter()
-        .map(|s| serde_json::json!({"name": s.name, "tools": 0}))
+        .map(|s| {
+            let tool_count = counts.get(&s.name).copied().unwrap_or(0);
+            serde_json::json!({"name": s.name, "tools": tool_count})
+        })
         .collect();
     serde_json::json!({
         "type": "mcp_update",

--- a/crates/core/src/shared_session.rs
+++ b/crates/core/src/shared_session.rs
@@ -1372,6 +1372,7 @@ async fn run_worker(
                 client,
                 tools: tool_infos,
             } => {
+                let tool_count = tool_infos.len();
                 for info in tool_infos {
                     let tool = crate::mcp::McpTool::new(client.clone(), info);
                     state.tool_registry.register(std::sync::Arc::new(tool));
@@ -1387,6 +1388,13 @@ async fn run_worker(
                     let _ = events_tx.send(ViewEvent::SlashOutput(format!(
                         "[mcp] '{server_name}' connected"
                     )));
+                }
+                // Update sidebar with real tool count now that the server is live.
+                #[cfg(feature = "gui")]
+                {
+                    crate::gui::update_mcp_tool_count(&server_name, tool_count);
+                    let payload = crate::gui::build_mcp_update_payload();
+                    let _ = events_tx.send(ViewEvent::McpUpdate(payload.to_string()));
                 }
             }
             ShellInput::McpFailed { server_name, error } => {


### PR DESCRIPTION
## Summary

`build_mcp_update_payload` was hardcoding `tools: 0` for every server because the config only holds names, not counts. The `McpReady` handler also never broadcast an update to the sidebar after tools connected.

Add a global `MCP_TOOL_COUNTS` map (updated on `McpReady`) so `build_mcp_update_payload` can surface real counts, and emit `ViewEvent::McpUpdate` from the `McpReady` handler so the sidebar refreshes as each server comes online.

## Motivation

## Changes

## Test plan

How did you verify this works?

- [x] `cargo test --features gui` passes locally
- [x] `cargo fmt --check` passes
- [ ] `cargo clippy --features gui -- -D warnings` passes
- [ ] Frontend type-check passes (`cd frontend && pnpm tsc --noEmit`) — if frontend touched
- [ ] Manually exercised the feature — steps:
  1. Start the `thclaws` on any project that configures MCP servers
  2. The MCP SERVERS on the left side of the UI should show MCP Servers with the number of tool calls.

## Screenshots / recordings

Before 

<img width="846" height="491" alt="Screenshot 2569-05-07 at 21 47 32" src="https://github.com/user-attachments/assets/386c1389-c0a3-4b52-9e3b-82cc039006c6" />

After
 
<img width="842" height="524" alt="Screenshot 2569-05-07 at 21 48 05" src="https://github.com/user-attachments/assets/db024407-891b-4f6d-8cf6-024c5ba0a77f" />

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if behavior changes (README / CHANGELOG / in-repo docs)
- [x] No new compiler warnings introduced
- [x] PR scope is focused — no unrelated changes
- [x] Commits follow project style (concise, imperative, optional `feat/fix/docs/...` prefix)
