### PR TITLE
fix(files): add close button to file preview panel

### DIFF
--- a/frontend/src/components/FilesView.tsx
+++ b/frontend/src/components/FilesView.tsx
@@ -271,6 +271,21 @@ export function FilesView({ active }: Props) {
     openFile(path);
   };
 
+  const closePreview = async () => {
+    if (mode === "edit" && editorDirty) {
+      const ok = await confirmNative({
+        title: "Discard unsaved changes",
+        message: `Discard unsaved edits to ${preview?.path ?? "this file"} and close?`,
+        yesLabel: "Discard",
+        noLabel: "Keep editing",
+      });
+      if (!ok) return;
+    }
+    setPreview(null);
+    setMode("preview");
+    setEditorDirty(false);
+  };
+
   const enterEditMode = () => {
     if (!preview) return;
     setMode("edit");
@@ -586,6 +601,14 @@ export function FilesView({ active }: Props) {
                     </button>
                   </>
                 )}
+                <button
+                  onClick={closePreview}
+                  className="flex items-center justify-center p-1 rounded hover:bg-white/5"
+                  style={{ color: "var(--text-secondary)" }}
+                  title="Close file"
+                >
+                  <X size={13} />
+                </button>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary

- Adds an X button at the end of the Files-tab toolbar to dismiss the preview pane
- Button sits after Edit (preview mode) and after Discard (edit mode)
- Prompts via native confirm dialog before closing if there are unsaved edits

## Test plan

- [x] Open a file → X button appears in toolbar
- [x] Click X → preview pane closes, returns to empty state
- [x] Open a file → Edit → make changes → click X → native confirm appears
- [x] Confirm discard → pane closes; cancel → stays in edit mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)