### PR TITLE
fix(providers): add 30s idle timeout to streaming chunk loop

### DIFF
--- a/crates/core/src/providers/anthropic.rs
+++ b/crates/core/src/providers/anthropic.rs
@@ -302,7 +302,17 @@ impl Provider for AnthropicProvider {
             let mut buffer: Vec<u8> = Vec::new();
             let mut byte_stream = Box::pin(byte_stream);
             let mut raw = raw_dump;
-            while let Some(chunk) = byte_stream.next().await {
+            loop {
+                let maybe_chunk = tokio::time::timeout(
+                    super::STREAM_CHUNK_TIMEOUT,
+                    byte_stream.next(),
+                )
+                .await
+                .map_err(|_| Error::Provider(format!(
+                    "stream idle for {}s — provider stopped sending; try again",
+                    super::STREAM_CHUNK_TIMEOUT.as_secs()
+                )))?;
+                let Some(chunk) = maybe_chunk else { break };
                 let chunk = chunk.map_err(|e| Error::Provider(format!("stream: {e}")))?;
                 buffer.extend_from_slice(&chunk);
 

--- a/crates/core/src/providers/gemini.rs
+++ b/crates/core/src/providers/gemini.rs
@@ -392,7 +392,17 @@ impl Provider for GeminiProvider {
             let mut log = debug_log;
             let mut raw = raw_dump;
 
-            while let Some(chunk) = byte_stream.next().await {
+            loop {
+                let maybe_chunk = tokio::time::timeout(
+                    super::STREAM_CHUNK_TIMEOUT,
+                    byte_stream.next(),
+                )
+                .await
+                .map_err(|_| Error::Provider(format!(
+                    "stream idle for {}s — provider stopped sending; try again",
+                    super::STREAM_CHUNK_TIMEOUT.as_secs()
+                )))?;
+                let Some(chunk) = maybe_chunk else { break };
                 let chunk = chunk.map_err(|e| Error::Provider(format!("stream: {e}")))?;
                 if let Some(f) = log.as_mut() {
                     use std::io::Write;

--- a/crates/core/src/providers/mod.rs
+++ b/crates/core/src/providers/mod.rs
@@ -8,6 +8,12 @@ use crate::types::{Message, ToolDef};
 use async_trait::async_trait;
 use futures::stream::BoxStream;
 
+/// Idle timeout applied to each individual chunk in a streaming response.
+/// If the provider sends no bytes for this many seconds the stream is
+/// aborted with an error so the UI surfaces a "try again" message instead
+/// of hanging silently until the user force-quits.
+pub(super) const STREAM_CHUNK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 pub mod agent_sdk;
 pub mod anthropic;
 pub mod assemble;

--- a/crates/core/src/providers/openai.rs
+++ b/crates/core/src/providers/openai.rs
@@ -427,7 +427,17 @@ impl Provider for OpenAIProvider {
             let mut state = ParseState::default();
             let mut raw = raw_dump;
 
-            while let Some(chunk) = byte_stream.next().await {
+            loop {
+                let maybe_chunk = tokio::time::timeout(
+                    super::STREAM_CHUNK_TIMEOUT,
+                    byte_stream.next(),
+                )
+                .await
+                .map_err(|_| Error::Provider(format!(
+                    "stream idle for {}s — provider stopped sending; try again",
+                    super::STREAM_CHUNK_TIMEOUT.as_secs()
+                )))?;
+                let Some(chunk) = maybe_chunk else { break };
                 let chunk = chunk.map_err(|e| Error::Provider(format!("stream: {e}")))?;
                 buffer.extend_from_slice(&chunk);
 


### PR DESCRIPTION
## Summary

- All three streaming providers (Anthropic, OpenAI, Gemini) blocked indefinitely on `byte_stream.next().await` if the provider stopped sending chunks without closing the connection
- Wraps each chunk read with `tokio::time::timeout(30s)` — on expiry the stream aborts with a human-readable error so the user knows what happened and can retry
- Timeout constant `STREAM_CHUNK_TIMEOUT` lives in `providers/mod.rs` and applies uniformly across all providers

<img width="1227" height="340" alt="Screenshot 2569-05-11 at 14 59 33" src="https://github.com/user-attachments/assets/be6e23e6-a31f-4405-8f39-7c4f6194117b" />
บอกว่าจะไปหาข้อมูลให้แต่ค้างไปเลย

## Test plan

- [x] Normal streaming works as before (timeout resets on every chunk)
- [x] Simulate a stalled stream — error message appears in UI within 30s instead of hanging indefinitely
- [x] Verify all three providers (Anthropic, OpenAI, Gemini) surface the error correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)