### PR TITLE
fix(providers): extend 30s stream idle timeout to remaining providers

### DIFF
--- a/crates/core/src/providers/ollama.rs
+++ b/crates/core/src/providers/ollama.rs
@@ -285,7 +285,17 @@ impl Provider for OllamaProvider {
             let mut state = ParseState::with_tools(tool_names);
             let mut raw = raw_dump;
 
-            while let Some(chunk) = byte_stream.next().await {
+            loop {
+                let maybe_chunk = tokio::time::timeout(
+                    super::STREAM_CHUNK_TIMEOUT,
+                    byte_stream.next(),
+                )
+                .await
+                .map_err(|_| Error::Provider(format!(
+                    "stream idle for {}s — provider stopped sending; try again",
+                    super::STREAM_CHUNK_TIMEOUT.as_secs()
+                )))?;
+                let Some(chunk) = maybe_chunk else { break };
                 let chunk = chunk.map_err(|e| Error::Provider(format!("stream: {e}")))?;
                 buffer.extend_from_slice(&chunk);
 

--- a/crates/core/src/providers/ollama_cloud.rs
+++ b/crates/core/src/providers/ollama_cloud.rs
@@ -243,7 +243,17 @@ impl Provider for OllamaCloudProvider {
             let mut state = super::ollama::ParseState::default();
             let mut raw = raw_dump;
 
-            while let Some(chunk) = byte_stream.next().await {
+            loop {
+                let maybe_chunk = tokio::time::timeout(
+                    super::STREAM_CHUNK_TIMEOUT,
+                    byte_stream.next(),
+                )
+                .await
+                .map_err(|_| Error::Provider(format!(
+                    "stream idle for {}s — provider stopped sending; try again",
+                    super::STREAM_CHUNK_TIMEOUT.as_secs()
+                )))?;
+                let Some(chunk) = maybe_chunk else { break };
                 let chunk = chunk.map_err(|e| Error::Provider(format!("stream: {e}")))?;
                 buffer.extend_from_slice(&chunk);
 

--- a/crates/core/src/providers/openai_responses.rs
+++ b/crates/core/src/providers/openai_responses.rs
@@ -242,7 +242,17 @@ impl Provider for OpenAIResponsesProvider {
             let mut seen_start = false;
             let mut raw = raw_dump;
 
-            while let Some(chunk) = byte_stream.next().await {
+            loop {
+                let maybe_chunk = tokio::time::timeout(
+                    super::STREAM_CHUNK_TIMEOUT,
+                    byte_stream.next(),
+                )
+                .await
+                .map_err(|_| Error::Provider(format!(
+                    "stream idle for {}s — provider stopped sending; try again",
+                    super::STREAM_CHUNK_TIMEOUT.as_secs()
+                )))?;
+                let Some(chunk) = maybe_chunk else { break };
                 let chunk = chunk.map_err(|e| Error::Provider(format!("stream: {e}")))?;
                 buffer.extend_from_slice(&chunk);
 


### PR DESCRIPTION
## Summary

- Follow-up to #81 — extends the same per-chunk `tokio::time::timeout(STREAM_CHUNK_TIMEOUT, byte_stream.next())` pattern to the three streaming providers that #81 didn't cover
- Patched: `openai_responses.rs`, `ollama.rs`, `ollama_cloud.rs`
- Uses the existing `pub(super) STREAM_CHUNK_TIMEOUT` constant from `providers/mod.rs` (already in main) — same 30 s, same error wording, so the user-visible message stays uniform across every streaming surface
- Net: +33 lines (11 per file, byte-identical to the #81 transformation modulo surrounding context)

## Test plan

- [x] `cargo check --features gui` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --features gui --lib providers` — 124 / 124 pass
- [ ] CI verifies fmt / clippy / typecheck / build×3 OS / test×2 OS

🤖 Generated with [Claude Code](https://claude.com/claude-code)