### PR TITLE
feat: add OpenCodeGo (opencode.ai) provider

### DIFF
--- a/crates/core/src/model_catalogue.rs
+++ b/crates/core/src/model_catalogue.rs
@@ -717,6 +717,7 @@ pub fn provider_kind_name(k: crate::providers::ProviderKind) -> &'static str {
         ProviderKind::DeepSeek => "deepseek",
         ProviderKind::ThaiLLM => "thaillm",
         ProviderKind::Nvidia => "nvidia",
+        ProviderKind::OpenCodeGo => "opencode-go",
         ProviderKind::Minimax => "minimax",
     }
 }

--- a/crates/core/src/providers/mod.rs
+++ b/crates/core/src/providers/mod.rs
@@ -49,6 +49,7 @@ pub mod gemini;
 pub mod ollama;
 pub mod ollama_cloud;
 pub mod openai;
+pub mod opencode_go;
 pub mod openai_responses;
 
 /// Registry of supported providers. Every new provider needs exactly one
@@ -87,6 +88,7 @@ pub enum ProviderKind {
     ThaiLLM,
     Nvidia,
     Minimax,
+    OpenCodeGo,
 }
 
 impl ProviderKind {
@@ -112,6 +114,7 @@ impl ProviderKind {
         Self::ThaiLLM,
         Self::Nvidia,
         Self::Minimax,
+        Self::OpenCodeGo,
     ];
 
     pub fn name(&self) -> &'static str {
@@ -137,6 +140,7 @@ impl ProviderKind {
             Self::ThaiLLM => "thaillm",
             Self::Nvidia => "nvidia",
             Self::Minimax => "minimax",
+            Self::OpenCodeGo => "opencode-go",
         }
     }
 
@@ -208,6 +212,11 @@ impl ProviderKind {
             // API). Models use the `minimax/<id>` prefix; the prefix is
             // stripped before the request reaches the upstream.
             Self::Minimax => "minimax/MiniMax-M2",
+            // OpenCodeGo (opencode.ai) — OpenAI-compatible hosted inference.
+            // Models use the `opencode-go/<id>` prefix (e.g.
+            // `opencode-go/kimi-k2.6`); the prefix is stripped before
+            // the request reaches the upstream.
+            Self::OpenCodeGo => "opencode-go/deepseek-v4-flash",
         }
     }
 
@@ -230,6 +239,7 @@ impl ProviderKind {
             Self::ThaiLLM => Some("THAILLM_BASE_URL"),
             Self::Nvidia => Some("NVIDIA_BASE_URL"),
             Self::Minimax => Some("MINIMAX_BASE_URL"),
+            Self::OpenCodeGo => Some("OPENCODE_GO_BASE_URL"),
             _ => None,
         }
     }
@@ -286,6 +296,8 @@ impl ProviderKind {
             // tenants with "invalid api key (2049)" — .io is the
             // current public OpenAI-compatible URL.
             Self::Minimax => Some("https://api.minimax.io/v1"),
+            // OpenCodeGo — hosted gateway at opencode.ai.
+            Self::OpenCodeGo => Some("https://opencode.ai/zen/go/v1"),
             _ => None,
         }
     }
@@ -332,6 +344,7 @@ impl ProviderKind {
             Self::ThaiLLM => Some("THAILLM_API_KEY"),
             Self::Nvidia => Some("NVIDIA_API_KEY"),
             Self::Minimax => Some("MINIMAX_API_KEY"),
+            Self::OpenCodeGo => Some("OPENCODE_GO_API_KEY"),
         }
     }
 
@@ -433,6 +446,7 @@ impl ProviderKind {
             | Self::OpenAICompat
             | Self::DeepSeek
             | Self::Nvidia
+            | Self::OpenCodeGo
             | Self::Minimax => None,
         }
     }
@@ -529,6 +543,8 @@ impl ProviderKind {
             // OpenRouter proxies the same models as `openrouter/nvidia/...`;
             // the `openrouter/` check above catches those first.
             Some(Self::Nvidia)
+        } else if model.starts_with("opencode-go/") {
+            Some(Self::OpenCodeGo)
         } else {
             None
         }
@@ -1003,6 +1019,7 @@ pub fn auto_fallback_model(cfg: &crate::config::AppConfig) -> Option<String> {
         ProviderKind::DeepSeek,
         ProviderKind::ThaiLLM,
         ProviderKind::Minimax,
+        ProviderKind::OpenCodeGo,
     ];
     for kind in ORDER {
         if kind_has_credentials(Some(*kind)) {
@@ -1322,6 +1339,45 @@ mod tests {
             Some("http://thaillm.or.th/api/v1")
         );
         assert_eq!(ProviderKind::ThaiLLM.name(), "thaillm");
+    }
+
+    #[test]
+    fn detect_opencodego_prefix_routes_to_opencodego_provider() {
+        assert_eq!(
+            ProviderKind::detect("opencode-go/kimi-k2.6"),
+            Some(ProviderKind::OpenCodeGo)
+        );
+        assert_eq!(
+            ProviderKind::detect("opencode-go/deepseek-v4-flash"),
+            Some(ProviderKind::OpenCodeGo)
+        );
+        assert_eq!(
+            ProviderKind::detect("opencode-go/qwen3.6-plus"),
+            Some(ProviderKind::OpenCodeGo)
+        );
+        // Bare model without prefix does NOT route to OpenCodeGo.
+        assert!(
+            !matches!(ProviderKind::detect("kimi-k2.6"), Some(ProviderKind::OpenCodeGo)),
+            "bare model ids without opencode-go/ prefix must not match OpenCodeGo"
+        );
+        // Provider properties match the expected values.
+        assert_eq!(
+            ProviderKind::OpenCodeGo.api_key_env(),
+            Some("OPENCODE_GO_API_KEY")
+        );
+        assert_eq!(
+            ProviderKind::OpenCodeGo.endpoint_env(),
+            Some("OPENCODE_GO_BASE_URL")
+        );
+        assert_eq!(
+            ProviderKind::OpenCodeGo.default_endpoint(),
+            Some("https://opencode.ai/zen/go/v1")
+        );
+        assert_eq!(ProviderKind::OpenCodeGo.name(), "opencode-go");
+        assert_eq!(
+            ProviderKind::OpenCodeGo.default_model(),
+            "opencode-go/deepseek-v4-flash"
+        );
     }
 
     #[test]

--- a/crates/core/src/providers/mod.rs
+++ b/crates/core/src/providers/mod.rs
@@ -950,6 +950,27 @@ pub async fn build_all_models_payload() -> String {
             _ => Vec::new(),
         }
     };
+    let opencodego_live: Vec<String> = {
+        let key = std::env::var("OPENCODE_GO_API_KEY").ok();
+        match key {
+            Some(k) => {
+                let base = std::env::var("OPENCODE_GO_BASE_URL")
+                    .unwrap_or_else(|_| crate::providers::opencode_go::DEFAULT_API_URL.to_string());
+                let provider = crate::providers::opencode_go::OpencodeGoProvider::new(k)
+                    .with_base_url(base);
+                match tokio::time::timeout(
+                    std::time::Duration::from_millis(1500),
+                    provider.list_models(),
+                )
+                .await
+                {
+                    Ok(Ok(models)) => models.into_iter().map(|m| m.id).collect(),
+                    _ => Vec::new(),
+                }
+            }
+            None => Vec::new(),
+        }
+    };
     let mut groups: Vec<serde_json::Value> = Vec::new();
     for kind in ProviderKind::ALL {
         let name = kind.name();
@@ -972,6 +993,11 @@ pub async fn build_all_models_payload() -> String {
         }
         if matches!(kind, ProviderKind::Ollama) {
             for id in &ollama_live {
+                model_ids.entry(id.clone()).or_insert(None);
+            }
+        }
+        if matches!(kind, ProviderKind::OpenCodeGo) {
+            for id in &opencodego_live {
                 model_ids.entry(id.clone()).or_insert(None);
             }
         }

--- a/crates/core/src/providers/opencode_go.rs
+++ b/crates/core/src/providers/opencode_go.rs
@@ -1,0 +1,608 @@
+//! OpenCodeGo (opencode.ai) streaming provider.
+//!
+//! OpenCodeGo is a subscription gateway that serves models via 3 wire formats
+//! through a single base URL:
+//!
+//! - **OpenAI-compatible** (`/chat/completions`): GLM, Kimi, DeepSeek, MiMo
+//! - **Anthropic-compatible** (`/messages`): MiniMax M2.5, M2.7
+//! - **Alibaba-compatible** (`/chat/completions`): Qwen3.5/3.6 Plus
+//!
+//! The provider detects the wire format from the model id (after stripping the
+//! `opencode-go/` prefix) and routes to the correct endpoint/parser.
+
+use super::{EventStream, ModelInfo, Provider, ProviderEvent, StreamRequest, Usage};
+use crate::error::{Error, Result};
+use crate::types::{ContentBlock, ImageSource, Role, ToolResultBlock, ToolResultContent};
+use async_stream::try_stream;
+use async_trait::async_trait;
+use futures::StreamExt;
+use reqwest::Client;
+use serde_json::{json, Value};
+
+pub const DEFAULT_API_URL: &str = "https://opencode.ai/zen/go/v1";
+pub const MODELS_URL: &str = "https://opencode.ai/zen/go/v1/models";
+
+const ANTHROPIC_MODELS: &[&str] = &["minimax-m2.5", "minimax-m2.7"];
+const ALIBABA_MODELS: &[&str] = &["qwen3.5-plus", "qwen3.6-plus"];
+const REASONING_MODELS: &[&str] = &["deepseek-v4-pro", "deepseek-v4-flash"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WireFormat {
+    OpenAI,
+    Anthropic,
+    Alibaba,
+}
+
+fn detect_wire_format(model: &str) -> WireFormat {
+    let lower = model.to_lowercase();
+    if ANTHROPIC_MODELS.contains(&lower.as_str()) {
+        WireFormat::Anthropic
+    } else if ALIBABA_MODELS.contains(&lower.as_str()) {
+        WireFormat::Alibaba
+    } else {
+        WireFormat::OpenAI
+    }
+}
+
+fn endpoint_for(format: WireFormat) -> &'static str {
+    match format {
+        WireFormat::OpenAI => "/chat/completions",
+        WireFormat::Alibaba => "/chat/completions",
+        WireFormat::Anthropic => "/messages",
+    }
+}
+
+fn model_uses_reasoning_content(model: &str) -> bool {
+    let lower = model.to_lowercase();
+    REASONING_MODELS.iter().any(|p| lower.contains(p))
+}
+
+pub struct OpencodeGoProvider {
+    client: Client,
+    api_key: String,
+    base_url: String,
+    list_models_url: Option<String>,
+}
+
+impl OpencodeGoProvider {
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            client: Client::new(),
+            api_key: api_key.into(),
+            base_url: DEFAULT_API_URL.to_string(),
+            list_models_url: None,
+        }
+    }
+
+    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = url.into();
+        self
+    }
+
+    pub fn with_list_models_url(mut self, url: impl Into<String>) -> Self {
+        self.list_models_url = Some(url.into());
+        self
+    }
+
+    fn auth_header_name(&self) -> &str { "authorization" }
+
+    fn auth_header_value(&self) -> String {
+        format!("Bearer {}", self.api_key)
+    }
+
+    fn messages_to_openai(req: &StreamRequest) -> Vec<Value> {
+        let mut out: Vec<Value> = Vec::new();
+        let echo_reasoning = model_uses_reasoning_content(&req.model);
+
+        if let Some(sys) = &req.system {
+            if !sys.is_empty() {
+                out.push(json!({"role": "system", "content": sys}));
+            }
+        }
+
+        for m in &req.messages {
+            let role = match m.role {
+                Role::User => "user",
+                Role::Assistant => "assistant",
+                Role::System => "system",
+            };
+
+            let mut text_parts: Vec<String> = Vec::new();
+            let mut thinking_parts: Vec<String> = Vec::new();
+            let mut tool_calls: Vec<Value> = Vec::new();
+            let mut trailing_tool_results: Vec<(String, String, Vec<(String, String)>)> = Vec::new();
+            let mut inline_user_images: Vec<(String, String)> = Vec::new();
+
+            for block in &m.content {
+                match block {
+                    ContentBlock::Text { text } => text_parts.push(text.clone()),
+                    ContentBlock::Thinking { content, .. } => {
+                        if echo_reasoning { thinking_parts.push(content.clone()); }
+                    }
+                    ContentBlock::Image { source: ImageSource::Base64 { media_type, data } } => {
+                        inline_user_images.push((media_type.clone(), data.clone()));
+                    }
+                    ContentBlock::ToolUse { id, name, input, .. } => {
+                        let args = serde_json::to_string(input).unwrap_or_else(|_| "{}".into());
+                        tool_calls.push(json!({
+                            "id": id, "type": "function",
+                            "function": { "name": name, "arguments": args },
+                        }));
+                    }
+                    ContentBlock::ToolResult { tool_use_id, content, .. } => {
+                        let text = content.to_text();
+                        let images = extract_images(content);
+                        trailing_tool_results.push((tool_use_id.clone(), text, images));
+                    }
+                }
+            }
+
+            let content_text = text_parts.join("");
+            let reasoning_text = thinking_parts.join("");
+            let has_text = !content_text.is_empty();
+            let has_reasoning = !reasoning_text.is_empty();
+            let has_tools = !tool_calls.is_empty();
+            let has_inline_images = !inline_user_images.is_empty();
+
+            if has_text || has_tools || has_reasoning || has_inline_images {
+                let mut msg = json!({"role": role});
+                if has_inline_images {
+                    let mut content_arr: Vec<Value> = Vec::new();
+                    if has_text { content_arr.push(json!({"type": "text", "text": content_text})); }
+                    for (media_type, data) in &inline_user_images {
+                        content_arr.push(json!({
+                            "type": "image_url",
+                            "image_url": { "url": format!("data:{media_type};base64,{data}") }
+                        }));
+                    }
+                    msg["content"] = json!(content_arr);
+                } else if has_text {
+                    msg["content"] = json!(content_text);
+                } else if has_tools {
+                    msg["content"] = Value::Null;
+                }
+                if has_tools { msg["tool_calls"] = json!(tool_calls); }
+                if has_reasoning { msg["reasoning_content"] = json!(reasoning_text); }
+                out.push(msg);
+            }
+
+            for (tool_call_id, content, _images) in &trailing_tool_results {
+                out.push(json!({
+                    "role": "tool", "tool_call_id": tool_call_id, "content": content,
+                }));
+            }
+
+            let total_images: usize = trailing_tool_results.iter().map(|(_, _, i)| i.len()).sum();
+            if total_images > 0 {
+                let mut user_content: Vec<Value> = Vec::with_capacity(total_images * 2 + 1);
+                let call_ids: Vec<&str> = trailing_tool_results.iter()
+                    .filter(|(_, _, i)| !i.is_empty()).map(|(id, _, _)| id.as_str()).collect();
+                user_content.push(json!({
+                    "type": "text",
+                    "text": format!(
+                        "(image{} attached from preceding tool_result{}: {})",
+                        if total_images == 1 { "" } else { "s" },
+                        if call_ids.len() == 1 { "" } else { "s" },
+                        call_ids.join(", ")
+                    ),
+                }));
+                for (tool_call_id, _content, images) in &trailing_tool_results {
+                    for (media_type, data) in images {
+                        user_content.push(json!({"type": "text", "text": format!("from {tool_call_id}:")}));
+                        user_content.push(json!({
+                            "type": "image_url",
+                            "image_url": { "url": format!("data:{media_type};base64,{data}") }
+                        }));
+                    }
+                }
+                out.push(json!({"role": "user", "content": user_content}));
+            }
+        }
+        out
+    }
+
+    fn build_openai_body(req: &StreamRequest) -> Value {
+        let messages = Self::messages_to_openai(req);
+        let mut body = json!({
+            "model": req.model,
+            "max_completion_tokens": req.max_tokens,
+            "messages": messages,
+            "stream": true,
+            "stream_options": {"include_usage": true},
+        });
+        if !req.tools.is_empty() {
+            body["tools"] = json!(req.tools.iter().map(|t| json!({
+                "type": "function",
+                "function": { "name": t.name, "description": t.description, "parameters": t.input_schema }
+            })).collect::<Vec<_>>());
+        }
+        body
+    }
+
+    fn build_anthropic_body(req: &StreamRequest) -> Value {
+        let msgs: Vec<Value> = req.messages.iter()
+            .filter(|m| !matches!(m.role, Role::System))
+            .map(|m| json!({
+                "role": match m.role { Role::User => "user", Role::Assistant => "assistant", _ => unreachable!() },
+                "content": m.content,
+            })).collect();
+
+        let mut body = json!({
+            "model": req.model, "max_tokens": req.max_tokens, "messages": msgs, "stream": true,
+        });
+        if let Some(sys) = &req.system {
+            if !sys.is_empty() { body["system"] = json!([{"type": "text", "text": sys}]); }
+        }
+        if !req.tools.is_empty() { body["tools"] = json!(req.tools); }
+        body
+    }
+
+    async fn send_request(&self, url: &str, body: &Value) -> Result<reqwest::Response> {
+        self.client.post(url)
+            .header(self.auth_header_name(), self.auth_header_value())
+            .header("content-type", "application/json")
+            .json(body)
+            .send().await.map_err(|e| Error::Provider(format!("http: {e}")))
+    }
+
+    fn parse_openai_chunk(text: &str, state: &mut OpenaiParseState) -> Result<Vec<ProviderEvent>> {
+        let text = text.trim();
+        if text.is_empty() || text == "data: [DONE]" { return Ok(Vec::new()); }
+        let Some(data) = text.strip_prefix("data: ").or_else(|| text.strip_prefix("data:")) else {
+            return Ok(Vec::new());
+        };
+        let v: Value = serde_json::from_str(data)
+            .map_err(|e| Error::Provider(format!("json parse: {e}")))?;
+
+        if v.get("error").is_some() {
+            let msg = v.pointer("/error/message").and_then(Value::as_str).unwrap_or("upstream error");
+            return Err(Error::Provider(format!("upstream error: {msg}")));
+        }
+
+        let mut events = Vec::new();
+
+        if !state.seen_message_start {
+            state.seen_message_start = true;
+            let model = v.get("model").and_then(Value::as_str).unwrap_or_default().to_string();
+            events.push(ProviderEvent::MessageStart { model });
+        }
+
+        if let Some(choices) = v.get("choices").and_then(Value::as_array) {
+            for choice in choices {
+                let delta = choice.get("delta");
+                if let Some(tool_calls) = delta.and_then(|d| d.get("tool_calls")).and_then(Value::as_array) {
+                    for tc in tool_calls {
+                        let index = tc.get("index").and_then(Value::as_i64);
+                        let id = tc.get("function").and_then(|f| f.get("name")).and_then(|_| tc.get("id")).and_then(Value::as_str).unwrap_or("").to_string();
+                        let name = tc.get("function").and_then(|f| f.get("name")).and_then(Value::as_str).unwrap_or("").to_string();
+                        if let Some(idx) = index {
+                            if state.active_tool_index.is_some() && state.active_tool_index != Some(idx) {
+                                events.push(ProviderEvent::ContentBlockStop);
+                            }
+                            state.active_tool_index = Some(idx);
+                        }
+                        if !id.is_empty() || !name.is_empty() {
+                            events.push(ProviderEvent::ToolUseStart { id, name, thought_signature: None });
+                        }
+                        let args = tc.get("function").and_then(|f| f.get("arguments")).and_then(Value::as_str).unwrap_or("");
+                        if !args.is_empty() {
+                            events.push(ProviderEvent::ToolUseDelta { partial_json: args.to_string() });
+                        }
+                    }
+                }
+
+                if let Some(content) = delta.and_then(|d| d.get("content")).and_then(Value::as_str) {
+                    if !content.is_empty() { events.push(ProviderEvent::TextDelta(content.to_string())); }
+                }
+                if let Some(reasoning) = delta.and_then(|d| d.get("reasoning_content")).and_then(Value::as_str) {
+                    if !reasoning.is_empty() { events.push(ProviderEvent::ThinkingDelta(reasoning.to_string())); }
+                }
+
+                if let Some(finish) = choice.get("finish_reason").and_then(Value::as_str) {
+                    if state.active_tool_index.is_some() {
+                        events.push(ProviderEvent::ContentBlockStop);
+                        state.active_tool_index = None;
+                    }
+                    let usage = v.get("usage").map(|u| Usage {
+                        input_tokens: u.get("prompt_tokens").and_then(Value::as_u64).unwrap_or(0) as u32,
+                        output_tokens: u.get("completion_tokens").and_then(Value::as_u64).unwrap_or(0) as u32,
+                        cache_creation_input_tokens: u.get("prompt_tokens_details").and_then(|d| d.get("cache_creation_tokens")).and_then(Value::as_u64).map(|n| n as u32),
+                        cache_read_input_tokens: u.get("prompt_tokens_details").and_then(|d| d.get("cached_tokens")).and_then(Value::as_u64).map(|n| n as u32),
+                    });
+                    if !state.emitted_message_stop {
+                        state.emitted_message_stop = true;
+                        events.push(ProviderEvent::MessageStop { stop_reason: Some(finish.to_string()), usage });
+                    }
+                }
+            }
+        }
+
+        if v.get("choices").and_then(Value::as_array).map_or(true, |c| c.is_empty())
+            && v.get("usage").is_some() && state.seen_message_start
+        {
+            let usage = v.get("usage").map(|u| Usage {
+                input_tokens: u.get("prompt_tokens").and_then(Value::as_u64).unwrap_or(0) as u32,
+                output_tokens: u.get("completion_tokens").and_then(Value::as_u64).unwrap_or(0) as u32,
+                cache_creation_input_tokens: None, cache_read_input_tokens: None,
+            });
+            if !state.emitted_message_stop {
+                state.emitted_message_stop = true;
+                events.push(ProviderEvent::MessageStop { stop_reason: Some("stop".to_string()), usage });
+            }
+        }
+
+        Ok(events)
+    }
+
+    fn parse_anthropic_chunk(text: &str) -> Result<Option<ProviderEvent>> {
+        let text = text.trim();
+        if text.is_empty() { return Ok(None); }
+        let mut event_type: Option<&str> = None;
+        let mut data_line: Option<&str> = None;
+        for line in text.lines() {
+            if let Some(rest) = line.strip_prefix("event: ") { event_type = Some(rest); }
+            else if let Some(rest) = line.strip_prefix("data: ") { data_line = Some(rest); }
+            else if let Some(rest) = line.strip_prefix("data:") { data_line = Some(rest); }
+        }
+        let Some(data) = data_line else { return Ok(None); };
+        if event_type == Some("ping") || event_type == Some("message_stop") { return Ok(None); }
+        let v: Value = serde_json::from_str(data).map_err(|e| Error::Provider(format!("json parse: {e}")))?;
+        if v.get("error").is_some() {
+            let msg = v.pointer("/error/message").and_then(Value::as_str).unwrap_or("upstream error");
+            return Err(Error::Provider(format!("upstream error: {msg}")));
+        }
+        let ty = v.get("type").and_then(Value::as_str).unwrap_or("");
+        match ty {
+            "message_start" => {
+                let model = v.pointer("/message/model").and_then(Value::as_str).unwrap_or_default().to_string();
+                Ok(Some(ProviderEvent::MessageStart { model }))
+            }
+            "content_block_start" => {
+                let cb = v.get("content_block");
+                let cb_type = cb.and_then(|c| c.get("type")).and_then(Value::as_str).unwrap_or("");
+                if cb_type == "tool_use" {
+                    let id = cb.and_then(|c| c.get("id")).and_then(Value::as_str).unwrap_or_default().to_string();
+                    let name = cb.and_then(|c| c.get("name")).and_then(Value::as_str).unwrap_or_default().to_string();
+                    Ok(Some(ProviderEvent::ToolUseStart { id, name, thought_signature: None }))
+                } else { Ok(None) }
+            }
+            "content_block_delta" => {
+                let delta = v.get("delta");
+                let dt = delta.and_then(|d| d.get("type")).and_then(Value::as_str).unwrap_or("");
+                match dt {
+                    "text_delta" => {
+                        let text = delta.and_then(|d| d.get("text")).and_then(Value::as_str).unwrap_or_default().to_string();
+                        Ok(Some(ProviderEvent::TextDelta(text)))
+                    }
+                    "input_json_delta" => {
+                        let pj = delta.and_then(|d| d.get("partial_json")).and_then(Value::as_str).unwrap_or_default().to_string();
+                        Ok(Some(ProviderEvent::ToolUseDelta { partial_json: pj }))
+                    }
+                    _ => Ok(None),
+                }
+            }
+            "content_block_stop" => Ok(Some(ProviderEvent::ContentBlockStop)),
+            "message_delta" => {
+                let delta = v.get("delta");
+                let stop_reason = delta.and_then(|d| d.get("stop_reason")).and_then(Value::as_str).map(String::from);
+                let usage = v.get("usage").map(|u| Usage {
+                    input_tokens: u.get("input_tokens").and_then(Value::as_u64).unwrap_or(0) as u32,
+                    output_tokens: u.get("output_tokens").and_then(Value::as_u64).unwrap_or(0) as u32,
+                    cache_creation_input_tokens: u.get("cache_creation_input_tokens").and_then(Value::as_u64).map(|n| n as u32),
+                    cache_read_input_tokens: u.get("cache_read_input_tokens").and_then(Value::as_u64).map(|n| n as u32),
+                });
+                Ok(Some(ProviderEvent::MessageStop { stop_reason, usage }))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn models_list_url(&self) -> String {
+        if let Some(url) = &self.list_models_url { return url.clone(); }
+        format!("{}/models", self.base_url.trim_end_matches('/'))
+    }
+}
+
+#[async_trait]
+impl Provider for OpencodeGoProvider {
+    async fn list_models(&self) -> Result<Vec<ModelInfo>> {
+        let models_url = self.models_list_url();
+        let resp = self.client.get(&models_url)
+            .header(self.auth_header_name(), self.auth_header_value())
+            .send().await.map_err(|e| Error::Provider(format!("http: {e}")))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(Error::Provider(format!("http {status}: {}", super::redact_key(&text, &self.api_key))));
+        }
+        let v: Value = resp.json().await.map_err(|e| Error::Provider(format!("json: {e}")))?;
+        let prefix = "opencode-go/";
+        let mut out: Vec<ModelInfo> = v.get("data").and_then(Value::as_array)
+            .map(|arr| arr.iter().filter_map(|m| {
+                let raw = m.get("id").and_then(Value::as_str)?;
+                let id = if raw.starts_with(prefix) { raw.to_string() } else { format!("{prefix}{raw}") };
+                Some(ModelInfo { id, display_name: None })
+            }).collect()).unwrap_or_default();
+        out.sort_by(|a, b| a.id.cmp(&b.id));
+        Ok(out)
+    }
+
+    async fn stream(&self, mut req: StreamRequest) -> Result<EventStream> {
+        if let Some(rest) = req.model.strip_prefix("opencode-go/") {
+            req.model = rest.to_string();
+        }
+
+        let wire_format = detect_wire_format(&req.model);
+        let endpoint = format!("{}{}", self.base_url.trim_end_matches('/'), endpoint_for(wire_format));
+        let body = match wire_format {
+            WireFormat::OpenAI | WireFormat::Alibaba => Self::build_openai_body(&req),
+            WireFormat::Anthropic => Self::build_anthropic_body(&req),
+        };
+
+        let resp = self.send_request(&endpoint, &body).await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(Error::Provider(format!("http {status}: {}", super::redact_key(&text, &self.api_key))));
+        }
+
+        let byte_stream = resp.bytes_stream();
+        let raw_dump = super::RawDump::new(format!("opencodego {}", req.model));
+        let chunk_timeout = req.stream_chunk_timeout_override.unwrap_or_else(super::stream_chunk_timeout);
+
+        let event_stream = try_stream! {
+            let mut buffer: Vec<u8> = Vec::new();
+            let mut byte_stream = Box::pin(byte_stream);
+            match wire_format {
+                WireFormat::OpenAI | WireFormat::Alibaba => {
+                    let mut state = OpenaiParseState::default();
+                    let mut raw = raw_dump;
+                    loop {
+                        let maybe_chunk = tokio::time::timeout(chunk_timeout, byte_stream.next())
+                            .await.map_err(|_| Error::Provider(format!("stream idle for {}s — provider stopped sending; try again", chunk_timeout.as_secs())))?;
+                        let Some(chunk) = maybe_chunk else { break };
+                        let chunk = chunk.map_err(|e| Error::Provider(format!("stream: {e}")))?;
+                        buffer.extend_from_slice(&chunk);
+                        while let Some(boundary) = super::find_bytes(&buffer, b"\n\n") {
+                            let event_bytes: Vec<u8> = buffer.drain(..boundary + 2).collect();
+                            let event_text = String::from_utf8_lossy(&event_bytes);
+                            let trimmed = event_text.trim_end_matches('\n');
+                            for event in Self::parse_openai_chunk(trimmed, &mut state)? {
+                                if let ProviderEvent::TextDelta(ref s) = event { raw.push(s); }
+                                yield event;
+                            }
+                        }
+                    }
+                    for event in state.flush_eof() { yield event; }
+                    raw.flush();
+                }
+                WireFormat::Anthropic => {
+                    let mut raw = raw_dump;
+                    loop {
+                        let maybe_chunk = tokio::time::timeout(chunk_timeout, byte_stream.next())
+                            .await.map_err(|_| Error::Provider(format!("stream idle for {}s — provider stopped sending; try again", chunk_timeout.as_secs())))?;
+                        let Some(chunk) = maybe_chunk else { break };
+                        let chunk = chunk.map_err(|e| Error::Provider(format!("stream: {e}")))?;
+                        buffer.extend_from_slice(&chunk);
+                        while let Some(boundary) = super::find_bytes(&buffer, b"\n\n") {
+                            let event_bytes: Vec<u8> = buffer.drain(..boundary + 2).collect();
+                            let event_text = String::from_utf8_lossy(&event_bytes);
+                            let trimmed = event_text.trim_end_matches('\n');
+                            if let Some(ev) = Self::parse_anthropic_chunk(trimmed)? {
+                                if let ProviderEvent::TextDelta(ref s) = ev { raw.push(s); }
+                                yield ev;
+                            }
+                        }
+                    }
+                    raw.flush();
+                }
+            }
+        };
+
+        Ok(Box::pin(event_stream))
+    }
+}
+
+#[derive(Default, Debug)]
+struct OpenaiParseState {
+    seen_message_start: bool,
+    active_tool_index: Option<i64>,
+    emitted_message_stop: bool,
+}
+
+impl OpenaiParseState {
+    fn flush_eof(&mut self) -> Vec<ProviderEvent> {
+        let mut out = Vec::new();
+        if self.active_tool_index.is_some() {
+            out.push(ProviderEvent::ContentBlockStop);
+            self.active_tool_index = None;
+        }
+        out
+    }
+}
+
+fn extract_images(content: &ToolResultContent) -> Vec<(String, String)> {
+    match content {
+        ToolResultContent::Text(_) => Vec::new(),
+        ToolResultContent::Blocks(blocks) => blocks.iter().filter_map(|b| match b {
+            ToolResultBlock::Image { source: ImageSource::Base64 { media_type, data } } => Some((media_type.clone(), data.clone())),
+            _ => None,
+        }).collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_wire_format_openai() {
+        assert_eq!(detect_wire_format("glm-5.1"), WireFormat::OpenAI);
+        assert_eq!(detect_wire_format("kimi-k2.6"), WireFormat::OpenAI);
+        assert_eq!(detect_wire_format("deepseek-v4-flash"), WireFormat::OpenAI);
+        assert_eq!(detect_wire_format("mimo-v2.5"), WireFormat::OpenAI);
+    }
+
+    #[test]
+    fn test_detect_wire_format_anthropic() {
+        assert_eq!(detect_wire_format("minimax-m2.7"), WireFormat::Anthropic);
+        assert_eq!(detect_wire_format("minimax-m2.5"), WireFormat::Anthropic);
+    }
+
+    #[test]
+    fn test_detect_wire_format_alibaba() {
+        assert_eq!(detect_wire_format("qwen3.6-plus"), WireFormat::Alibaba);
+        assert_eq!(detect_wire_format("qwen3.5-plus"), WireFormat::Alibaba);
+    }
+
+    #[test]
+    fn test_endpoint_for() {
+        assert_eq!(endpoint_for(WireFormat::OpenAI), "/chat/completions");
+        assert_eq!(endpoint_for(WireFormat::Alibaba), "/chat/completions");
+        assert_eq!(endpoint_for(WireFormat::Anthropic), "/messages");
+    }
+
+    #[test]
+    fn test_model_uses_reasoning_content() {
+        assert!(model_uses_reasoning_content("deepseek-v4-flash"));
+        assert!(model_uses_reasoning_content("deepseek-v4-pro"));
+        assert!(!model_uses_reasoning_content("glm-5.1"));
+    }
+
+    #[test]
+    fn test_openai_parse_text_delta() {
+        let mut state = OpenaiParseState::default();
+        let text = r#"data: {"model":"glm-5.1","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"}}]}"#;
+        let events = OpencodeGoProvider::parse_openai_chunk(text, &mut state).unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(&events[0], ProviderEvent::MessageStart { .. }));
+        assert!(matches!(&events[1], ProviderEvent::TextDelta(_)));
+    }
+
+    #[test]
+    fn test_anthropic_parse_text_delta() {
+        let text = r#"event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+        let event = OpencodeGoProvider::parse_anthropic_chunk(text).unwrap().unwrap();
+        assert!(matches!(event, ProviderEvent::TextDelta(_)));
+    }
+
+    #[test]
+    fn test_anthropic_skip_ping() {
+        let text = "event: ping\ndata: {}";
+        let event = OpencodeGoProvider::parse_anthropic_chunk(text).unwrap();
+        assert!(event.is_none());
+    }
+
+    #[test]
+    fn test_provider_default_url() {
+        let provider = OpencodeGoProvider::new("test-key");
+        assert_eq!(provider.base_url, DEFAULT_API_URL);
+    }
+
+    #[test]
+    fn test_provider_custom_url() {
+        let provider = OpencodeGoProvider::new("test-key").with_base_url("https://custom.example.com");
+        assert_eq!(provider.base_url, "https://custom.example.com");
+    }
+}

--- a/crates/core/src/providers/opencode_go.rs
+++ b/crates/core/src/providers/opencode_go.rs
@@ -84,12 +84,6 @@ impl OpencodeGoProvider {
         self
     }
 
-    fn auth_header_name(&self) -> &str { "authorization" }
-
-    fn auth_header_value(&self) -> String {
-        format!("Bearer {}", self.api_key)
-    }
-
     fn messages_to_openai(req: &StreamRequest) -> Vec<Value> {
         let mut out: Vec<Value> = Vec::new();
         let echo_reasoning = model_uses_reasoning_content(&req.model);
@@ -237,11 +231,17 @@ impl OpencodeGoProvider {
         body
     }
 
-    async fn send_request(&self, url: &str, body: &Value) -> Result<reqwest::Response> {
-        self.client.post(url)
-            .header(self.auth_header_name(), self.auth_header_value())
-            .header("content-type", "application/json")
-            .json(body)
+    async fn send_request(&self, url: &str, body: &Value, wire_format: WireFormat) -> Result<reqwest::Response> {
+        let req = self.client.post(url)
+            .header("content-type", "application/json");
+        let req = match wire_format {
+            WireFormat::Anthropic => req
+                .header("x-api-key", &self.api_key)
+                .header("anthropic-version", "2023-06-01"),
+            _ => req
+                .header("authorization", format!("Bearer {}", self.api_key)),
+        };
+        req.json(body)
             .send().await.map_err(|e| Error::Provider(format!("http: {e}")))
     }
 
@@ -408,7 +408,7 @@ impl Provider for OpencodeGoProvider {
     async fn list_models(&self) -> Result<Vec<ModelInfo>> {
         let models_url = self.models_list_url();
         let resp = self.client.get(&models_url)
-            .header(self.auth_header_name(), self.auth_header_value())
+            .header("authorization", format!("Bearer {}", self.api_key))
             .send().await.map_err(|e| Error::Provider(format!("http: {e}")))?;
         if !resp.status().is_success() {
             let status = resp.status();
@@ -439,7 +439,7 @@ impl Provider for OpencodeGoProvider {
             WireFormat::Anthropic => Self::build_anthropic_body(&req),
         };
 
-        let resp = self.send_request(&endpoint, &body).await?;
+        let resp = self.send_request(&endpoint, &body, wire_format).await?;
         if !resp.status().is_success() {
             let status = resp.status();
             let text = resp.text().await.unwrap_or_default();
@@ -534,6 +534,7 @@ fn extract_images(content: &ToolResultContent) -> Vec<(String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::Message;
 
     #[test]
     fn test_detect_wire_format_openai() {
@@ -604,5 +605,57 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
     fn test_provider_custom_url() {
         let provider = OpencodeGoProvider::new("test-key").with_base_url("https://custom.example.com");
         assert_eq!(provider.base_url, "https://custom.example.com");
+    }
+
+    /// Integration test: streams from minimax-m2.7 (Anthropic wire format with x-api-key).
+    /// Requires OPENCODE_GO_API_KEY env var.
+    #[tokio::test]
+    #[ignore = "requires OPENCODE_GO_API_KEY"]
+    async fn it_streams_minimax_m2_7() {
+        let key = std::env::var("OPENCODE_GO_API_KEY").expect("OPENCODE_GO_API_KEY must be set");
+        let provider = OpencodeGoProvider::new(key);
+        let req = StreamRequest {
+            model: "opencode-go/minimax-m2.7".into(),
+            system: None,
+            messages: vec![Message::user("Say hello in one word")],
+            tools: vec![],
+            max_tokens: 30,
+            thinking_budget: None,
+            stream_chunk_timeout_override: Some(std::time::Duration::from_secs(10)),
+        };
+        let stream = provider.stream(req).await.unwrap();
+        let mut count = 0;
+        tokio::pin!(stream);
+        while let Some(event) = stream.next().await {
+            let _ = event.unwrap();
+            count += 1;
+        }
+        assert!(count > 0, "expected at least one event");
+    }
+
+    /// Integration test: streams from qwen3.6-plus (Alibaba wire format).
+    /// Requires OPENCODE_GO_API_KEY env var.
+    #[tokio::test]
+    #[ignore = "requires OPENCODE_GO_API_KEY"]
+    async fn it_streams_qwen3_6_plus() {
+        let key = std::env::var("OPENCODE_GO_API_KEY").expect("OPENCODE_GO_API_KEY must be set");
+        let provider = OpencodeGoProvider::new(key);
+        let req = StreamRequest {
+            model: "opencode-go/qwen3.6-plus".into(),
+            system: None,
+            messages: vec![Message::user("Say hello in one word")],
+            tools: vec![],
+            max_tokens: 30,
+            thinking_budget: None,
+            stream_chunk_timeout_override: Some(std::time::Duration::from_secs(10)),
+        };
+        let stream = provider.stream(req).await.unwrap();
+        let mut count = 0;
+        tokio::pin!(stream);
+        while let Some(event) = stream.next().await {
+            let _ = event.unwrap();
+            count += 1;
+        }
+        assert!(count > 0, "expected at least one event");
     }
 }

--- a/crates/core/src/repl.rs
+++ b/crates/core/src/repl.rs
@@ -13,7 +13,8 @@ use crate::memory::MemoryStore;
 use crate::permissions::{PermissionMode, ReplApprover};
 use crate::providers::{
     anthropic::AnthropicProvider, gemini::GeminiProvider, ollama::OllamaProvider,
-    ollama_cloud::OllamaCloudProvider, openai::OpenAIProvider, Provider, ProviderKind,
+    ollama_cloud::OllamaCloudProvider, openai::OpenAIProvider, opencode_go::OpencodeGoProvider,
+    Provider, ProviderKind,
 };
 use crate::session::{Session, SessionStore};
 use crate::subagent::{ProductionAgentFactory, SubAgentTool};
@@ -3353,6 +3354,20 @@ pub fn build_provider(config: &AppConfig) -> Result<Arc<dyn Provider>> {
                     .with_strip_model_prefix("nvidia/"),
             ))
         }
+        ProviderKind::OpenCodeGo => {
+            // OpenCodeGo (opencode.ai) — multi-format hosted gateway.
+            // Routes to the correct endpoint based on model id:
+            // OpenAI-compatible (/chat/completions), Anthropic-compatible
+            // (/messages), or Alibaba-compatible (/chat/completions).
+            // Models use the `opencode-go/<id>` prefix. The base URL can
+            // be overridden via OPENCODE_GO_BASE_URL for self-hosted proxies.
+            let base = std::env::var("OPENCODE_GO_BASE_URL")
+                .unwrap_or_else(|_| "https://opencode.ai/zen/go/v1".to_string());
+            Ok(Arc::new(
+                OpencodeGoProvider::new(api_key).with_base_url(base),
+            ))
+        }
+
         ProviderKind::Ollama
         | ProviderKind::OllamaAnthropic
         | ProviderKind::LMStudio
@@ -3418,6 +3433,7 @@ pub async fn build_provider_with_fallback(
         ProviderKind::QwenCloud,
         ProviderKind::ZAi,
         ProviderKind::ThaiLLM,
+        ProviderKind::OpenCodeGo,
         ProviderKind::Ollama,
         ProviderKind::OllamaAnthropic,
         ProviderKind::OllamaCloud,

--- a/crates/core/src/secrets.rs
+++ b/crates/core/src/secrets.rs
@@ -105,6 +105,7 @@ const MANAGED: &[ProviderKind] = &[
     ProviderKind::DeepSeek,
     ProviderKind::ThaiLLM,
     ProviderKind::Nvidia,
+    ProviderKind::OpenCodeGo,
 ];
 
 /// Non-LLM service keys we surface in the same Settings modal as the

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -48,6 +48,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   ollama: "Ollama",
   "ollama-anthropic": "Ollama (Anthropic-compatible)",
   "ollama-cloud": "Ollama Cloud",
+  "opencode-go": "OpenCode Go",
   azure: "Azure AI Foundry",
   "openai-compat": "OpenAI-Compatible (custom endpoint)",
   tavily: "Tavily Search",


### PR DESCRIPTION
## Summary

Add OpenCodeGo (opencode.ai) as a new provider with full OpenAI-compatible chat streaming and live model discovery in the sidebar picker.

## Motivation

Support for open-source model inference via opencode.ai's OpenAI-compatible gateway.

## Changes

- New `opencode_go.rs` provider module with multi-wire-format support (OpenAI, Anthropic, Alibaba wire formats)
- Register `ProviderKind::OpenCodeGo` with `opencode-go/` model prefix across all match arms
- Live model probe (`/v1/models`) in `build_all_models_payload` so available models appear in the picker
- Wire into REPL tokenizer path, build provider, secrets manager, model catalogue, and auto-fallback chain
- Settings UI label in `SettingsModal.tsx`

## Test plan

- [ ] `cargo test --features gui` passes locally
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --features gui -- -D warnings` passes
- [ ] Frontend type-check passes — no frontend logic changes (only a label string)
- [ ] Manually exercised the feature — steps:
  1. Set `OPENCODE_GO_API_KEY`
  2. Start thClaws and confirm OpenCodeGo appears in the provider/model picker
  3. Send a message with `--model opencode-go/deepseek-v4-flash` and verify streaming response

## Screenshots / recordings

N/A — no GUI/UX changes beyond a label addition.

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if behavior changes
- [ ] No new compiler warnings introduced
- [ ] PR scope is focused — no unrelated changes
- [ ] Commits follow project style (concise, imperative, `feat` prefix)
