### PR TITLE
fix userid when running the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,12 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # ──────────────────────────────────────────────────────────────────────
 FROM ${RUNTIME_BASE} AS runtime
 
-ARG USERNAME=thaclaws
+# Run as non-root. Override USER_UID/USER_GID at build time so files
+# written to the bind-mounted /workspace are owned by your host user:
+#   docker build \
+#     --build-arg USER_UID=$(id -u) \
+#     --build-arg USER_GID=$(id -g) ...
+ARG USERNAME=thclaws
 ARG USER_UID=1000
 ARG USER_GID=1000
 
@@ -92,9 +97,6 @@ RUN groupadd --gid ${USER_GID} ${USERNAME} \
 COPY --from=builder /usr/local/bin/thclaws /usr/local/bin/thclaws
 
 WORKDIR /workspace
-
-# Ensure mounted workspace is writable
-RUN chown -R ${USER_UID}:${USER_GID} /workspace
 
 EXPOSE 8443
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # ──────────────────────────────────────────────────────────────────────
 FROM ${RUNTIME_BASE} AS runtime
 
+ARG USERNAME=thaclaws
+ARG USER_UID=1000
+ARG USER_GID=1000
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
         libgtk-3-0 \
         libwebkit2gtk-4.1-0 \
@@ -77,15 +81,30 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ripgrep \
     && rm -rf /var/lib/apt/lists/*
 
+# Create group + user matching host UID/GID
+RUN groupadd --gid ${USER_GID} ${USERNAME} \
+    && useradd --uid ${USER_UID} \
+               --gid ${USER_GID} \
+               --create-home \
+               --shell /bin/bash \
+               ${USERNAME}
+
 COPY --from=builder /usr/local/bin/thclaws /usr/local/bin/thclaws
 
 WORKDIR /workspace
+
+# Ensure mounted workspace is writable
+RUN chown -R ${USER_UID}:${USER_GID} /workspace
+
 EXPOSE 8443
 
 ENV THCLAWS_INSIDE_DOCKER=1
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
     CMD curl -fsS http://127.0.0.1:8443/healthz || exit 1
+
+# Switch to non-root user
+USER ${USER_UID}:${USER_GID}
 
 ENTRYPOINT ["thclaws"]
 CMD ["--serve", "--bind", "0.0.0.0", "--port", "8443"]


### PR DESCRIPTION
## Summary

Briefly describe what this PR does.

## Motivation

Why is this change needed? Link the issue it closes (e.g. `Closes #123`).

## Changes

- In v0.9.7, the default userid of thaclaws container is 'root'. When the container writes files, they will be owned by root, not the current USERID. This will make the user can not change or modify files if they don't have root privilege on that machine.
- I add the default container userid as 'thclaws' . The UID/GID will be the same as HOST's current ones. 

## Test plan
Build the new container on my local and check permission.

How did you verify this works?

- [ NO CHANGE] `cargo test --features gui` passes locally
- [ NO CHANGE] `cargo fmt --check` passes
- [ NO CHANGE] `cargo clippy --features gui -- -D warnings` passes
- [ NO CHANGE] Frontend type-check passes (`cd frontend && pnpm tsc --noEmit`) — if frontend touched
- [ ] Manually exercised the feature — steps:
  1. Create new thaclaw container on my local machine
  2. start the new container and check effective UID/GID and write permissions

## Screenshots / recordings

<img width="959" height="964" alt="new_container" src="https://github.com/user-attachments/assets/73411e85-6595-44ed-8df7-f84def232269" />


For GUI / CLI U

X changes, include a before / after screenshot or short recording.
Before:
<img width="1152" height="262" alt="Screenshot 2026-05-15 111636" src="https://github.com/user-attachments/assets/e04827c3-dbeb-42d3-bec6-e79fa7a9f9a8" />

After:
<img width="711" height="354" alt="Screenshot 2026-05-15 123003" src="https://github.com/user-attachments/assets/38df73d6-f33e-458c-a70f-54461bd1e50b" />

## Checklist

- [PASS ] Tests added or updated
- [ ] Documentation updated if behavior changes (README / CHANGELOG / in-repo docs)
- [ ] No new compiler warnings introduced
- [ ] PR scope is focused — no unrelated changes
- [ ] Commits follow project style (concise, imperative, optional `feat/fix/docs/...` prefix)
