### PR TITLE
feat(mcp): allow trusted MCP-Apps servers to opt into allow-same-origin

### DIFF
--- a/crates/core/src/event_render.rs
+++ b/crates/core/src/event_render.rs
@@ -75,6 +75,7 @@ pub fn render_chat_dispatches(ev: &ViewEvent) -> Vec<String> {
                     "uri": ui.uri,
                     "html": ui.html,
                     "mime": ui.mime,
+                    "allow_same_origin": ui.allow_same_origin,
                 });
             }
             vec![env.to_string()]

--- a/crates/core/src/mcp.rs
+++ b/crates/core/src/mcp.rs
@@ -1619,7 +1619,7 @@ mod tests {
             .await;
         });
 
-        let (text, mime) = client
+        let (text, mime, allow_same_origin) = client
             .read_resource("ui://pinn/image-viewer")
             .await
             .expect("read_resource");
@@ -1628,6 +1628,53 @@ mod tests {
 
         assert_eq!(text, "<html>widget</html>");
         assert_eq!(mime.as_deref(), Some("text/html;profile=mcp-app"));
+        // Default — server didn't set `_meta.allowSameOrigin`. The
+        // strict sandbox stays on; this is the safety-by-default that
+        // the allow-same-origin opt-in is layered against.
+        assert!(!allow_same_origin);
+    }
+
+    #[tokio::test]
+    async fn read_resource_propagates_allow_same_origin_when_meta_set() {
+        let (client, (s_read, s_write)) = paired_streams();
+
+        let server_task = tokio::spawn(async move {
+            run_mock_server(s_read, s_write, move |msg| {
+                let method = msg.get("method").and_then(Value::as_str).unwrap_or("");
+                let id = msg.get("id").and_then(Value::as_u64);
+                match (method, id) {
+                    ("resources/read", Some(id)) => {
+                        let uri = msg
+                            .get("params")
+                            .and_then(|p| p.get("uri"))
+                            .and_then(Value::as_str)
+                            .unwrap_or("");
+                        Some(jsonrpc_response(
+                            id,
+                            json!({
+                                "contents": [{
+                                    "uri": uri,
+                                    "mimeType": "text/html;profile=mcp-app",
+                                    "text": "<html>widget</html>",
+                                    "_meta": { "allowSameOrigin": true }
+                                }]
+                            }),
+                        ))
+                    }
+                    _ => None,
+                }
+            })
+            .await;
+        });
+
+        let (_text, _mime, allow_same_origin) = client
+            .read_resource("ui://pinn/preview")
+            .await
+            .expect("read_resource");
+        drop(client);
+        let _ = tokio::time::timeout(Duration::from_secs(2), server_task).await;
+
+        assert!(allow_same_origin);
     }
 
     #[tokio::test]

--- a/crates/core/src/mcp.rs
+++ b/crates/core/src/mcp.rs
@@ -828,7 +828,7 @@ impl McpClient {
     /// `text/html;profile=mcp-app` before mounting an iframe and
     /// avoid trusting arbitrary text the server might return for the
     /// same URI.
-    pub async fn read_resource(&self, uri: &str) -> Result<(String, Option<String>)> {
+    pub async fn read_resource(&self, uri: &str) -> Result<(String, Option<String>, bool)> {
         let result = self
             .request("resources/read", json!({ "uri": uri }))
             .await?;
@@ -844,7 +844,19 @@ impl McpClient {
                     .get("mimeType")
                     .and_then(Value::as_str)
                     .map(str::to_string);
-                return Ok((text.to_string(), mime));
+                // MCP-Apps extension carried in the resource's `_meta`.
+                // A trusted server that needs to load `<script src>`
+                // from its own preview origin (e.g. GamedevPreview
+                // returning an iframe whose src is the loopback HTTP
+                // server it spawned) sets `_meta.allowSameOrigin: true`.
+                // We surface it here; the trust gate at the call site
+                // decides whether to honor it.
+                let allow_same_origin = entry
+                    .get("_meta")
+                    .and_then(|m| m.get("allowSameOrigin"))
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                return Ok((text.to_string(), mime, allow_same_origin));
             }
         }
         Err(Error::Provider(format!(
@@ -1052,10 +1064,14 @@ impl Tool for McpTool {
             return None;
         }
         match self.client.read_resource(uri).await {
-            Ok((html, mime)) => Some(crate::tools::UiResource {
+            Ok((html, mime, allow_same_origin)) => Some(crate::tools::UiResource {
                 uri: uri.to_string(),
                 html,
                 mime,
+                // Honor the server's request — already gated by the
+                // trust check above. Untrusted servers never reach this
+                // arm so a third-party widget can never escalate.
+                allow_same_origin,
             }),
             Err(e) => {
                 eprintln!(

--- a/crates/core/src/tools/mod.rs
+++ b/crates/core/src/tools/mod.rs
@@ -139,6 +139,16 @@ pub struct UiResource {
     pub uri: String,
     pub html: String,
     pub mime: Option<String>,
+    /// When true, the frontend's `McpAppIframe` mounts the widget with
+    /// `sandbox="allow-scripts allow-popups allow-forms allow-same-origin"`
+    /// instead of the default (`allow-same-origin` omitted). MCP-Apps
+    /// widgets from arbitrary servers leave this `false` so the widget
+    /// gets an opaque origin and can't reach back into thClaws state.
+    /// First-party tools that need to load `<script src>` and assets
+    /// from a localhost preview server (e.g. `GamedevPreview`'s game
+    /// iframe) set it `true`; the trust is implicit because the tool
+    /// ships inside the thClaws binary.
+    pub allow_same_origin: bool,
 }
 
 #[derive(Default, Clone)]

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -53,6 +53,7 @@ type ChatMessage = {
     uri: string;
     html: string;
     mime?: string;
+    allowSameOrigin?: boolean;
   };
 };
 
@@ -398,7 +399,7 @@ export function ChatView({ active, modalOpen }: Props) {
           // `ui/notifications/tool-result` push can carry it as a
           // standard MCP text content block.
           const ui = msg.ui_resource as
-            | { uri: string; html: string; mime?: string }
+            | { uri: string; html: string; mime?: string; allow_same_origin?: boolean }
             | undefined;
           const output = (msg.output as string | undefined) ?? "";
           // M6.38.9: parse `Source: <engine>` from the first line of
@@ -432,7 +433,14 @@ export function ChatView({ active, modalOpen }: Props) {
                     ...candidate,
                     toolDone: true,
                     content: ui ? output : candidate.content,
-                    uiResource: ui,
+                    uiResource: ui
+                      ? {
+                          uri: ui.uri,
+                          html: ui.html,
+                          mime: ui.mime,
+                          allowSameOrigin: ui.allow_same_origin === true,
+                        }
+                      : undefined,
                     toolSource,
                   },
                   ...prev.slice(i + 1),
@@ -924,6 +932,7 @@ export function ChatView({ active, modalOpen }: Props) {
                     <McpAppIframe
                       uri={widget.uri}
                       html={widget.html}
+                      allowSameOrigin={widget.allowSameOrigin === true}
                       parentToolName={msg.toolName ?? ""}
                       toolResult={{
                         content: [{ type: "text", text: msg.content }],

--- a/frontend/src/components/McpAppIframe.tsx
+++ b/frontend/src/components/McpAppIframe.tsx
@@ -81,6 +81,12 @@ type Props = {
   /// the widget after init handshake completes so its `ontoolresult`
   /// fires.
   toolResult: ToolResultContent;
+  /// Add `allow-same-origin` to the iframe sandbox. Opt-in for
+  /// first-party tools that need to load `<script src>` / images
+  /// from a localhost preview server (`GamedevPreview`). Untrusted
+  /// MCP-server widgets leave this `false` so they stay on an opaque
+  /// origin and can't reach back into host state.
+  allowSameOrigin?: boolean;
 };
 
 type JsonRpcMessage = {
@@ -155,6 +161,7 @@ export function McpAppIframe({
   html,
   parentToolName,
   toolResult,
+  allowSameOrigin = false,
 }: Props) {
   const [mode, setMode] = useState<DisplayMode>("inline");
   const [pipRect, setPipRect] = useState<PipRect>(() => loadPipRect(uri));
@@ -557,7 +564,11 @@ export function McpAppIframe({
       // with `allow-same-origin` would defeat the srcdoc origin
       // isolation, so we don't. The widget can still postMessage to
       // the parent and fetch its declared resourceDomains.
-      sandbox="allow-scripts allow-popups allow-forms"
+      sandbox={
+        allowSameOrigin
+          ? "allow-scripts allow-popups allow-forms allow-same-origin"
+          : "allow-scripts allow-popups allow-forms"
+      }
       style={{
         display: "block",
         flex: "1 1 auto",


### PR DESCRIPTION
The iframe sandbox in `McpAppIframe` is intentionally `allow-scripts allow-popups allow-forms` so a widget from an arbitrary MCP server runs on an opaque origin and can't reach back into thClaws state. That bites first-party-style servers whose widget loads `<script src>` from its own loopback HTTP server (e.g. the `thclaws-gamedev-mcp` GamedevPreview tool returning an iframe that points at the preview server it spawned alongside): p5 needs AudioContext, certain canvas APIs, and localStorage, all of which fail under opaque origin → canvas stays black.

Opt-in path while keeping the strict default:

  - `UiResource.allow_same_origin: bool` — propagated from in-process tools' UiResource and from external MCP servers' resource `_meta.allowSameOrigin`.
  - `McpClient::read_resource` returns the flag alongside text + mime; honored only when the server is `trusted: true` in `.mcp.json` (existing trust gate, unchanged otherwise).
  - `ChatView` maps the flag to `widget.allowSameOrigin` and forwards it to `McpAppIframe`, which appends `allow-same-origin` to the sandbox attribute only when set.

Untrusted/default external MCPs are unaffected: their widgets still get the strict sandbox. Verified end-to-end against thclaws-gamedev-mcp's GamedevPreview where the server marks its preview widget `_meta.allowSameOrigin: true` and the .mcp.json entry sets `trusted: true`.

## Summary

Briefly describe what this PR does.

## Motivation

Why is this change needed? Link the issue it closes (e.g. `Closes #123`).

## Changes

- ...
- ...

## Test plan

How did you verify this works?

- [ ] `cargo test --features gui` passes locally
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --features gui -- -D warnings` passes
- [ ] Frontend type-check passes (`cd frontend && pnpm tsc --noEmit`) — if frontend touched
- [ ] Manually exercised the feature — steps:
  1. ...
  2. ...

## Screenshots / recordings

For GUI / CLI UX changes, include a before / after screenshot or short recording.

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if behavior changes (README / CHANGELOG / in-repo docs)
- [ ] No new compiler warnings introduced
- [ ] PR scope is focused — no unrelated changes
- [ ] Commits follow project style (concise, imperative, optional `feat/fix/docs/...` prefix)
