### PR TITLE
fix(webui): wire navigator.clipboard for Ctrl/Cmd+C/V in --serve mode

### DIFF
--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -408,26 +408,88 @@ export function TerminalView({ active, modalOpen }: Props) {
         return false;
       }
 
+      // Apply pasted text to the line buffer. Shared between the IPC
+      // (wry desktop) and navigator.clipboard (browser --serve) paths
+      // so both produce identical line-buffer / multi-line behaviour.
+      const MAX_PASTE_BYTES = 1 * 1024 * 1024;
+      const applyPastedText = (text: string) => {
+        if (text.length > MAX_PASTE_BYTES) {
+          console.warn(
+            `[paste] clipboard too large (${text.length} bytes); ignoring`,
+          );
+          return;
+        }
+        if (text.length === 0) return;
+        if (/\r?\n/.test(text)) {
+          // Multi-line paste: submit the whole thing as ONE shell_input.
+          // Erase any local echo; the backend's UserPrompt event will
+          // re-render the full block.
+          const combined = (lineBuffer + text).replace(/\r\n/g, "\n");
+          const trimmed = combined.replace(/\n+$/, "");
+          lineBuffer = "";
+          if (trimmed.length > 0) {
+            term.write("\x1b[2K\r");
+            send({ type: "shell_input", text: trimmed });
+          }
+        } else {
+          // Single-line paste: insert at the current caret position so
+          // pasting into the middle of an in-progress edit works the
+          // same as typing there. After the buffer change, recompute
+          // the slash-popup state in case the paste extended `/<word>`.
+          lineBuffer =
+            lineBuffer.slice(0, cursorPos) +
+            text +
+            lineBuffer.slice(cursorPos);
+          cursorPos += text.length;
+          redrawLine();
+          recomputeSlash();
+        }
+      };
+
+      // Browser-mode detection — true under `--serve` in a real browser
+      // (no wry IPC bridge). In that mode arboard on the SERVER would
+      // touch the wrong machine's clipboard; navigator.clipboard goes
+      // to the user's actual clipboard. In wry desktop mode `window.ipc`
+      // is present and navigator.clipboard is blocked, so we keep the
+      // existing arboard-via-IPC path. Fixes #96.
+      const inBrowserMode =
+        typeof window !== "undefined" && !window.ipc && !!navigator.clipboard;
+
       // Copy
       if (mod && e.key === "c" && e.type === "keydown") {
         const sel = term.getSelection();
         if (sel) {
-          send({ type: "clipboard_write", text: sel });
+          if (inBrowserMode) {
+            navigator.clipboard.writeText(sel).catch((err) => {
+              console.warn("[clipboard] writeText failed:", err);
+            });
+          } else {
+            send({ type: "clipboard_write", text: sel });
+          }
           return false;
         }
         if (!isMac) return false;
       }
 
-      // Paste
-      if (mod && e.key === "v" && e.type === "keydown") {
+      // Paste. Linux/Windows convention is Ctrl+Shift+V (covered by
+      // `mod`); also accept plain Ctrl+V on non-Mac since there's no
+      // ambiguous signal binding for it (unlike Ctrl+C / SIGINT).
+      const isPasteShortcut =
+        e.type === "keydown" &&
+        e.key === "v" &&
+        (mod || (!isMac && e.ctrlKey && !e.altKey && !e.metaKey));
+      if (isPasteShortcut) {
+        if (inBrowserMode) {
+          navigator.clipboard
+            .readText()
+            .then((text) => applyPastedText(text))
+            .catch((err) => console.warn("[clipboard] readText failed:", err));
+          return false;
+        }
         const unsub = subscribe((msg) => {
           if (msg.type === "clipboard_text") {
             unsub();
             if (!msg.ok) return;
-            // Cap on paste size — atob() and TextDecoder are sync and
-            // freeze the main thread on multi-MB inputs. 1 MB binary
-            // is ~1.33 MB base64; round up the b64 ceiling for safety.
-            const MAX_PASTE_BYTES = 1 * 1024 * 1024;
             const MAX_PASTE_B64 = Math.ceil((MAX_PASTE_BYTES * 4) / 3);
             let text = "";
             if (typeof msg.text_b64 === "string") {
@@ -442,41 +504,9 @@ export function TerminalView({ active, modalOpen }: Props) {
               for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
               text = new TextDecoder("utf-8").decode(bytes);
             } else if (typeof msg.text === "string") {
-              if (msg.text.length > MAX_PASTE_BYTES) {
-                console.warn(
-                  `[paste] clipboard too large (${msg.text.length} bytes); ignoring`,
-                );
-                return;
-              }
               text = msg.text as string;
             }
-            if (text.length > 0) {
-              if (/\r?\n/.test(text)) {
-                // Multi-line paste: submit the whole thing as ONE
-                // shell_input. Erase any local echo; the backend's
-                // UserPrompt event will re-render the full block.
-                const combined = (lineBuffer + text).replace(/\r\n/g, "\n");
-                const trimmed = combined.replace(/\n+$/, "");
-                lineBuffer = "";
-                if (trimmed.length > 0) {
-                  term.write("\x1b[2K\r");
-                  send({ type: "shell_input", text: trimmed });
-                }
-              } else {
-                // Single-line paste: insert at the current caret
-                // position so pasting into the middle of an in-progress
-                // edit works the same as typing there. After the
-                // buffer change, recompute the slash-popup state in
-                // case the paste extended a `/<word>` query.
-                lineBuffer =
-                  lineBuffer.slice(0, cursorPos) +
-                  text +
-                  lineBuffer.slice(cursorPos);
-                cursorPos += text.length;
-                redrawLine();
-                recomputeSlash();
-              }
-            }
+            applyPastedText(text);
           }
         });
         send({ type: "clipboard_read" });


### PR DESCRIPTION
## Summary

In `--serve` browser mode the existing clipboard shortcuts went through an IPC bridge to `arboard` on the **server** — that's the wrong machine's clipboard.

- Ctrl+Shift+C in the browser wrote to the host running `thclaws --serve`, not the user's laptop.
- Ctrl+Shift+V pulled the server's clipboard contents and pasted that.

The user couldn't tell things were going to the wrong machine — they just saw "nothing happens" or "garbage paste" and worked around it via the browser's right-click menu (reported in #96).

## Fix

Detect browser mode by absence of `window.ipc` (the wry IPC bridge) plus presence of `navigator.clipboard`, and route copy/paste through the browser's Clipboard API in that case.

- **GUI (wry desktop):** `window.ipc` is present, `navigator.clipboard` is blocked → keep the existing arboard-via-IPC path. No behaviour change.
- **`--serve` in a browser (secure context):** `window.ipc` undefined, `navigator.clipboard` available → use it directly, hitting the actual user's clipboard.
- **`--serve` in an insecure context (`http://192.168.x.x`):** `navigator.clipboard` is undefined under non-https / non-localhost; falls through to the existing IPC path. Same broken-but-non-crashing behaviour as before — operators should use https / SSH tunnel for clipboard to work, which the existing docs already recommend.

Also accept plain `Ctrl+V` on Linux/Windows for paste — no signal-key ambiguity (`Ctrl+C` stays as SIGINT regardless of selection per the project's existing convention). Mac stays on `Cmd+V` only.

## Why the refactor

Extracted the paste handling (multi-line vs single-line, size cap, slash-popup recompute) into a `applyPastedText(text: string)` helper so the IPC and navigator paths share the exact same line-buffer / submission behaviour. Previously the multi-line submit logic lived inside the IPC `subscribe` callback and would have needed to be copy-pasted into the navigator branch.

## Test plan

- [x] `cd frontend && pnpm tsc --noEmit` clean
- [x] `cd frontend && pnpm build` clean (vite + vite-plugin-singlefile)
- [x] No new lint issues in `TerminalView.tsx` (pre-existing lint errors in other files are unchanged)
- [ ] Manual smoke in GUI desktop mode — copy/paste still goes through native clipboard
- [ ] Manual smoke in `--serve` browser mode (https / localhost) — Ctrl+V pastes browser clipboard contents
- [ ] Manual smoke: select text in xterm + Ctrl+Shift+C → paste in another app

## Closes

Closes #96

Reported-By: takasungi