### PR TITLE
fix(sidebar): allow session switch + new-session while a turn is running

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -428,8 +428,20 @@ export function Sidebar({ onBrowseKms }: SidebarProps = {}) {
         action={
           <button
             className="p-0.5 rounded hover:bg-white/10"
-            title="New session (save current + clear)"
-            onClick={() => send({ type: "new_session" })}
+            title="New session (cancels active task + saves current + clears)"
+            onClick={() => {
+              // session_load / new_session are processed by the same
+              // single-threaded worker that runs agent turns; if a turn
+              // is in flight the swap message sits in the input queue
+              // until the turn finishes — issue #95(a): users expected
+              // the click to switch sessions immediately. Always fire
+              // shell_cancel first; it's idempotent on the backend
+              // (no-op when nothing is running) so it's safe to send
+              // even on an idle agent. Same reasoning as the Ctrl+C
+              // handler in TerminalView.tsx.
+              send({ type: "shell_cancel" });
+              send({ type: "new_session" });
+            }}
           >
             <Plus size={12} />
           </button>
@@ -474,7 +486,12 @@ export function Sidebar({ onBrowseKms }: SidebarProps = {}) {
                     color: "var(--text-primary)",
                     fontWeight: isCurrent ? 600 : 400,
                   }}
-                  onClick={() => send({ type: "session_load", id: s.id })}
+                  onClick={() => {
+                    // See "New session" button comment above for why
+                    // shell_cancel goes first — issue #95(a).
+                    send({ type: "shell_cancel" });
+                    send({ type: "session_load", id: s.id });
+                  }}
                   title={s.title ? `${s.title} (${s.id}) — ${s.messages} msg${isCurrent ? " — current" : ""}` : `${s.id} — ${s.messages} msg${isCurrent ? " — current" : ""}`}
                 >
                   <span


### PR DESCRIPTION
## Summary

Fixes #95 (part a): session swap clicks did nothing while a turn was running, then \"caught up\" once the task finished.

\`session_load\` / \`new_session\` both enqueue a \`ShellInput\` on the same single-threaded worker channel that runs agent turns. When a turn is in flight (\`handle_line\` is \`.await\`-ing the agent loop), the worker isn't reading from \`input_rx\`, so the swap sits in the queue until the turn completes.

## Fix

Fire \`shell_cancel\` before each \`session_load\` / \`new_session\` click. The cancel flips the worker's \`CancelToken\`, the running turn exits at its next await, and the worker picks up the queued \`LoadSession\` / \`NewSession\` next iteration.

\`shell_cancel\` is idempotent on the backend (no-op when nothing is running — see the comment in \`TerminalView.tsx\`), so always firing it is safe even when the worker is idle.

## Behaviour

| State | Before | After |
|---|---|---|
| Idle | Switches | Switches (same) |
| Mid-turn | Click does nothing; switch happens later when turn finishes | Click cancels current turn; switch happens immediately |

This matches the Cmd+Ctrl-tab pattern users expect from terminals + chat UIs — switching means \"abandon current work\".

## What this does NOT fix

#95 is a 3-in-1 report:
- (a) \"cannot select another session when leader got task\" — **this PR**
- (b) \"session list cap at 10\" — separate change to add pagination/search
- (c) \"team tab sometimes hidden\" — separate race-condition investigation

## Test plan

- [x] \`cd frontend && pnpm tsc --noEmit\` clean
- [x] \`cd frontend && pnpm build\` clean (vite singlefile)
- [ ] Manual: click a session while a turn is mid-stream → turn cancels + transcript jumps to clicked session
- [ ] Manual: click \"New session\" \`+\` button mid-turn → terminal clears + new session
- [ ] Manual: click session while idle → still works (no regression)

## Closes

Part a of #95

Reported-By: takasungi