### PR TITLE
fix(sidebar): searchable session list to surface > 10 named sessions

### DIFF
--- a/crates/core/src/shared_session.rs
+++ b/crates/core/src/shared_session.rs
@@ -2459,12 +2459,20 @@ pub(crate) fn save_history(agent: &Agent, session: &mut Session, store: &Option<
 }
 
 pub(crate) fn build_session_list(store: &Option<SessionStore>, current_id: &str) -> String {
+    // Was capped at 20 — but the sidebar shows the top 10 in the default
+    // view and the rest are reachable only via the search box (#95 part
+    // b). Bumping to 200 gives heavy users a meaningful searchable
+    // window (each entry is ~100 bytes JSON ⇒ ~20KB payload, fine over
+    // WebSocket). For workspaces with >200 sessions, a future change can
+    // move filtering server-side; for now the on-disk list() ordering
+    // (most-recently-updated first; see SessionStore::list) keeps the
+    // newest 200 visible.
     let sessions: Vec<serde_json::Value> = store
         .as_ref()
         .and_then(|s| s.list().ok())
         .unwrap_or_default()
         .into_iter()
-        .take(20)
+        .take(200)
         .map(|s| {
             serde_json::json!({
                 "id": s.id,

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -98,6 +98,13 @@ export function Sidebar({ onBrowseKms }: SidebarProps = {}) {
     { id: string; current: string } | null
   >(null);
   const renameInputRef = useRef<HTMLInputElement | null>(null);
+  // #95(b): when empty, the sidebar shows only the top 10 most-recent
+  // sessions (matches the pre-fix layout the user is used to). When
+  // typing, we filter the full received list (backend caps at 200, see
+  // build_session_list) by title + id substring match, case-insensitive,
+  // and uncap up to 50 matches so search is usable for named sessions
+  // that fall outside the top-10 default view.
+  const [sessionFilter, setSessionFilter] = useState("");
   // Plan-07 Phase 2.4: LINE bridge status pill. The worker
   // broadcasts `line_status` envelopes on connect / disconnect;
   // the pill is rendered only while `state === "connected"`.
@@ -451,8 +458,39 @@ export function Sidebar({ onBrowseKms }: SidebarProps = {}) {
           <div className="px-2 py-1" style={{ color: "var(--text-secondary)" }}>
             No saved sessions
           </div>
-        ) : (
-          sessions.slice(0, 10).map((s) => {
+        ) : (() => {
+          const q = sessionFilter.trim().toLowerCase();
+          const filtered = q.length === 0
+            ? sessions.slice(0, 10)
+            : sessions
+                .filter((s) =>
+                  (s.title?.toLowerCase().includes(q) ?? false) ||
+                  s.id.toLowerCase().includes(q),
+                )
+                .slice(0, 50);
+          return (
+            <>
+              <input
+                type="text"
+                value={sessionFilter}
+                onChange={(e) => setSessionFilter(e.target.value)}
+                placeholder={`Search ${sessions.length} session${sessions.length === 1 ? "" : "s"}…`}
+                aria-label="Filter sessions"
+                className="w-full mx-2 mb-1 px-1.5 py-0.5 rounded text-xs"
+                style={{
+                  width: "calc(100% - 1rem)",
+                  background: "var(--bg-secondary, rgba(255,255,255,0.04))",
+                  color: "var(--text-primary)",
+                  border: "1px solid var(--border, rgba(255,255,255,0.08))",
+                  outline: "none",
+                }}
+              />
+              {filtered.length === 0 ? (
+                <div className="px-2 py-1" style={{ color: "var(--text-secondary)", fontSize: "11px" }}>
+                  No matches for &ldquo;{sessionFilter.trim()}&rdquo;
+                </div>
+              ) : (
+                filtered.map((s) => {
             const label = s.title && s.title.trim().length > 0
               ? s.title
               : s.id;
@@ -504,7 +542,10 @@ export function Sidebar({ onBrowseKms }: SidebarProps = {}) {
               </div>
             );
           })
-        )}
+              )}
+            </>
+          );
+        })()}
       </Section>
 
       {/* Knowledge bases */}


### PR DESCRIPTION
## Summary

Fixes #95 (part b): the sidebar capped the visible sessions at the most-recent 10. Users who name sessions for cross-task organisation couldn't get back to older named sessions once they scrolled out of the top-10 window.

User's words:

> session list at left side bar have only last 10, my behavier like to create new session for new task that not relate, then when i found bug and want to back to that session that already have named i can not found at session list.

## Fix

**Backend** — \`build_session_list\` cap bumped from 20 → 200. \`SessionStore::list()\` is already ordered most-recently-updated first, so this preserves ordering and just gives the search box a meaningful corpus. Payload stays small (~20 KB over WebSocket for 200 entries).

**Frontend** — add a single-line search input above the Sessions list.

| State | Behaviour |
|---|---|
| Empty query | Top 10 most-recent (unchanged from before — no regression for users who don't search) |
| Active query | Case-insensitive substring match on \`title\` + \`id\`, capped at 50 hits to bound DOM size |
| Active query with no matches | "No matches for &ldquo;…&rdquo;" message |

## What this does NOT fix

- #95(a) "cannot select another session when leader got task" — already shipped in #98
- #95(c) "team tab sometimes hidden" — separate race-condition investigation

## Test plan

- [x] \`cd frontend && pnpm tsc --noEmit\` clean
- [x] \`cd frontend && pnpm build\` clean (vite singlefile)
- [x] \`cargo build --bin thclaws-cli\` clean
- [x] \`cargo fmt -- --check\` clean
- [ ] Manual: with > 10 named sessions, type part of a session name in the search field → only matching sessions visible
- [ ] Manual: clear the search field → returns to top-10 default view
- [ ] Manual: with < 10 sessions, search input still renders, default view unchanged

## Closes

Part b of #95

Reported-By: takasungi