### PR TITLE
fix(initial_state): ship team_enabled so Team tab heals on (re)connect

### DIFF
--- a/crates/core/src/gui.rs
+++ b/crates/core/src/gui.rs
@@ -1127,6 +1127,13 @@ fn run_gui_inner(serve: Option<crate::server::ServeConfig>) {
                     }))
                     .collect();
                 let kms_update = build_kms_update_payload();
+                // #95(c): mirror server.rs's initial_state so GUI mode
+                // ships team_enabled too. wry IPC is synchronous (no
+                // CONNECTING race), but keeping the two builders in
+                // lockstep avoids drift across the GUI / --serve split.
+                let team_enabled = crate::config::ProjectConfig::load()
+                    .and_then(|c| c.team_enabled)
+                    .unwrap_or(false);
                 let state = serde_json::json!({
                     "type": "initial_state",
                     "provider": provider_name,
@@ -1135,6 +1142,7 @@ fn run_gui_inner(serve: Option<crate::server::ServeConfig>) {
                     "mcp_servers": mcp_servers,
                     "sessions": sessions,
                     "kmss": kms_update.get("kmss").cloned().unwrap_or(serde_json::Value::Array(vec![])),
+                    "team_enabled": team_enabled,
                     "version": crate::version::VERSION,
                 });
                 let js = format!(

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -588,6 +588,15 @@ fn build_initial_state_payload() -> String {
         })
         .collect();
     let kmss = build_kms_initial_payload(&config);
+    // #95(c): on WS open the frontend's mount-time `team_enabled_get`
+    // request can be dropped if the socket is still CONNECTING — the
+    // wsSend guard logs and discards (frontend/src/hooks/useIPC.ts:114).
+    // Ship the flag here so every (re)connect-driven initial_state
+    // carries it and the Team tab heals automatically without the user
+    // having to open Settings to incidentally refire the get.
+    let team_enabled = crate::config::ProjectConfig::load()
+        .and_then(|c| c.team_enabled)
+        .unwrap_or(false);
     serde_json::json!({
         "type": "initial_state",
         "provider": provider_name,
@@ -596,6 +605,7 @@ fn build_initial_state_payload() -> String {
         "mcp_servers": mcp_servers,
         "sessions": sessions,
         "kmss": kmss,
+        "team_enabled": team_enabled,
         "version": crate::version::VERSION,
     })
     .to_string()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -418,6 +418,17 @@ export default function App() {
         typeof msg.enabled === "boolean"
       ) {
         setTeamEnabled(msg.enabled as boolean);
+      } else if (
+        msg.type === "initial_state" &&
+        typeof msg.team_enabled === "boolean"
+      ) {
+        // #95(c): the explicit `team_enabled_get` below races the WS
+        // CONNECTING state on first mount in --serve mode — wsSend
+        // drops the message if the socket isn't OPEN yet. initial_state
+        // fires on every WS (re)connect from the backend, so picking it
+        // up here heals the Team-tab-hidden race without requiring the
+        // user to open Settings to incidentally re-trigger the get.
+        setTeamEnabled(msg.team_enabled as boolean);
       }
     });
     send({ type: "team_enabled_get" });


### PR DESCRIPTION
## Summary

Fixes #95 (part c) — the last of takasungi's 3-in-1 webui bug report.

> sometime tab team not show but team are already spwan, when i push more task they will comeback or order to leader to respawn thery will come back or not.

## Root cause

In \`--serve\` browser mode, App.tsx's mount-time \`send({type: \"team_enabled_get\"})\` races the WebSocket CONNECTING state. The wsSend guard at \`frontend/src/hooks/useIPC.ts:114\` silently logs + discards messages sent before the socket reaches OPEN:

\`\`\`ts
wsSend = (msg) => {
  if (ws && ws.readyState === WebSocket.OPEN) {
    ws.send(JSON.stringify(msg));
  } else {
    console.warn(\"[ipc] ws not open, dropped:\", msg);  // ← here
  }
};
\`\`\`

The backend doesn't re-broadcast \`team_enabled\` spontaneously. \`initial_state\` (pushed on every WS connect via \`frontend_ready\`) didn't carry the flag either. So once the get was dropped, the only path back to \`teamEnabled=true\` was incidental — opening Settings (which has its own \`team_enabled_get\` on mount) or a coincidental tool action that triggered a stat refresh.

That matches the user's \"sometime ... will comeback or not\" exactly.

## Fix

Make \`initial_state\` carry the flag. It already fires reliably on every (re)connect; this just adds one field.

- \`server.rs\` \`build_initial_state_payload\`: include \`team_enabled\` from \`ProjectConfig\`.
- \`gui.rs\` \`SendInitialState\` arm: same, so the two builders stay in lockstep. (wry IPC doesn't have the race — this is just to avoid drift.)
- \`App.tsx\` team-enabled subscriber: pick up \`initial_state.team_enabled\` in addition to the existing \`team_enabled\` / \`team_enabled_result\` events. The explicit \`team_enabled_get\` send on mount stays as a belt-and-braces fallback.

Net: on every WS connect or reconnect the backend pushes the real \`team_enabled\` value; the frontend picks it up regardless of whether the mount-time get raced WS open.

## What this does NOT fix

- The same drop-on-CONNECTING pattern theoretically affects any \`send()\` from a top-level mount effect, not just \`team_enabled_get\`. A general queue-and-flush in \`useIPC.ts\` would solve them all at once but is a bigger change with its own ordering semantics to think through; this PR sticks to the user-reported regression.
- Doesn't touch #95(a) (shipped in #98) or #95(b) (shipped in #99).

## Test plan

- [x] \`cd frontend && pnpm tsc --noEmit\` clean
- [x] \`cd frontend && pnpm build\` clean (vite singlefile)
- [x] \`cargo build --bin thclaws-cli\` clean
- [x] \`cargo build --features gui\` clean
- [x] \`cargo fmt -- --check\` clean
- [ ] Manual smoke in \`--serve\` mode with \`team_enabled=true\` in project config — Team tab visible on first load + after F5 + after WS reconnect
- [ ] Manual smoke in GUI desktop — same (lockstep with --serve)

## Closes

Part c of #95 — completes the 3-in-1 issue.

Reported-By: takasungi