### PR TITLE
feat(api_v1): loopback /v1 bridge + auto-size for MCP-Apps iframes

### DIFF
--- a/crates/core/src/api_v1/chat.rs
+++ b/crates/core/src/api_v1/chat.rs
@@ -368,8 +368,14 @@ async fn run_turn_from_messages(req: &ChatRequest) -> crate::error::Result<Agent
 /// prompt, parameterized by the request's model + max_tokens. Shared
 /// between the non-stream and SSE paths.
 fn build_agent(req: &ChatRequest, extra_system: Option<String>) -> crate::error::Result<Agent> {
-    let mut config = AppConfig::default();
-    config.model = req.model.clone();
+    // Load the user's full config (~/.config/thclaws + project) so the
+    // configured default model is used when a caller (e.g. a widget's
+    // server-side tool call going through our loopback) omits `model`
+    // or sends `""`. Falls back to bare defaults if load fails.
+    let mut config = AppConfig::load().unwrap_or_default();
+    if !req.model.trim().is_empty() {
+        config.model = req.model.clone();
+    }
     if let Some(max) = req.max_tokens {
         config.max_tokens = max;
     }

--- a/crates/core/src/api_v1/mod.rs
+++ b/crates/core/src/api_v1/mod.rs
@@ -165,7 +165,9 @@ pub async fn spawn_loopback() -> std::io::Result<String> {
         }
     });
 
-    eprintln!("\x1b[36m[api_v1 loopback] /v1/* available at {url} for out-of-process MCP servers\x1b[0m");
+    eprintln!(
+        "\x1b[36m[api_v1 loopback] /v1/* available at {url} for out-of-process MCP servers\x1b[0m"
+    );
     Ok(url)
 }
 

--- a/crates/core/src/api_v1/mod.rs
+++ b/crates/core/src/api_v1/mod.rs
@@ -103,6 +103,72 @@ pub fn auth_is_bypassed() -> bool {
     matches!(auth_token(), AuthMode::Bypass)
 }
 
+/// Default loopback bind for the always-on `/v1/*` listener. The
+/// fixed port is the seam separately-spawned MCP-Apps servers (e.g.
+/// `thclaws-gamedev-mcp` running over HTTP transport on its own port)
+/// use to reach the user's authenticated provider — they don't share
+/// a process with us, so they can't inherit our env. A random port
+/// would force the operator to glue ports together by hand every
+/// restart; a fixed, documented one means `GamedevAiMove` just works.
+pub const LOOPBACK_DEFAULT_PORT: u16 = 18443;
+
+/// Override env for the fixed port — for the rare case of a host that
+/// already has 18443 in use, or two thClaws instances on one box.
+pub const LOOPBACK_PORT_ENV: &str = "THCLAWS_LOOPBACK_PORT";
+
+/// Bind the always-on loopback `/v1/*` listener. Resolves the port
+/// from `$THCLAWS_LOOPBACK_PORT` or falls back to
+/// [`LOOPBACK_DEFAULT_PORT`]. Auth is forced to `disable-auth` because
+/// the listener is loopback-only — the safety boundary is the bind
+/// address, not a bearer token an out-of-process MCP server would need
+/// to discover from us anyway.
+///
+/// Run once at startup. Logs the bound URL to stderr; returns it so the
+/// caller can stash it for in-process clients. Idempotent — a second
+/// call is a no-op and returns the existing URL.
+///
+/// Errors are surfaced for the caller to log+ignore: a failed bind
+/// (port collision) should NOT abort startup, because MCP-Apps widgets
+/// that don't need the bridge keep working without it.
+pub async fn spawn_loopback() -> std::io::Result<String> {
+    use std::sync::OnceLock;
+    static LOOPBACK_URL: OnceLock<String> = OnceLock::new();
+    if let Some(url) = LOOPBACK_URL.get() {
+        return Ok(url.clone());
+    }
+
+    let port: u16 = std::env::var(LOOPBACK_PORT_ENV)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(LOOPBACK_DEFAULT_PORT);
+
+    // Force disable-auth so out-of-process clients on the same host
+    // (HTTP-transport MCP servers, host scripts) don't need to learn a
+    // per-process bearer token to reach our /v1 surface. Safety is
+    // anchored to the loopback bind, not the token.
+    if std::env::var("THCLAWS_API_TOKEN")
+        .map(|v| v != "disable-auth")
+        .unwrap_or(true)
+    {
+        std::env::set_var("THCLAWS_API_TOKEN", "disable-auth");
+    }
+
+    let bind = format!("127.0.0.1:{port}");
+    let listener = tokio::net::TcpListener::bind(&bind).await?;
+    let url = format!("http://{bind}");
+    let _ = LOOPBACK_URL.set(url.clone());
+
+    let app = axum::Router::new().merge(router());
+    tokio::spawn(async move {
+        if let Err(e) = axum::serve(listener, app).await {
+            eprintln!("\x1b[33m[api_v1 loopback] serve error: {e}\x1b[0m");
+        }
+    });
+
+    eprintln!("\x1b[36m[api_v1 loopback] /v1/* available at {url} for out-of-process MCP servers\x1b[0m");
+    Ok(url)
+}
+
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     if a.len() != b.len() {
         return false;

--- a/crates/core/src/bin/app.rs
+++ b/crates/core/src/bin/app.rs
@@ -296,6 +296,26 @@ async fn main() {
         }
     }
 
+    // Always-on loopback `/v1/*` listener for out-of-process MCP-Apps
+    // servers that need to reach the user's authenticated LLM provider
+    // (e.g. thclaws-gamedev-mcp's HTTP-transport server forwarding game
+    // AI moves). Binds 127.0.0.1:18443 by default (override with
+    // $THCLAWS_LOOPBACK_PORT) with `THCLAWS_API_TOKEN=disable-auth` so
+    // the out-of-process server doesn't need to discover a per-launch
+    // token. Skipped under `--print` (short-lived runs don't host MCP
+    // widgets) and `--serve` (that path already mounts /v1 on the
+    // user's chosen bind; a parallel loopback would double-bind on
+    // operators who pick 18443 for serve, and serve users know their
+    // own URL already). Bind failures are logged + ignored — MCP-Apps
+    // widgets that don't need the bridge keep working without it.
+    if !cli.print && !cli.serve {
+        if let Err(e) = thclaws_core::api_v1::spawn_loopback().await {
+            eprintln!(
+                "\x1b[33m[api_v1] loopback listener failed to bind: {e} — out-of-process MCP-Apps tools relying on the /v1 bridge (e.g. GamedevAiMove) won't be reachable; set THCLAWS_LOOPBACK_PORT to pick a free port\x1b[0m"
+            );
+        }
+    }
+
     // M6.36 SERVE5: --serve mode short-circuits the CLI/GUI dispatch.
     // Single-purpose deployment shape — operator runs one process per
     // project on a server. Gated behind `gui` because crate::server

--- a/crates/core/src/event_render.rs
+++ b/crates/core/src/event_render.rs
@@ -76,6 +76,7 @@ pub fn render_chat_dispatches(ev: &ViewEvent) -> Vec<String> {
                     "html": ui.html,
                     "mime": ui.mime,
                     "allow_same_origin": ui.allow_same_origin,
+                    "auto_size": ui.auto_size,
                 });
             }
             vec![env.to_string()]

--- a/crates/core/src/mcp.rs
+++ b/crates/core/src/mcp.rs
@@ -828,10 +828,7 @@ impl McpClient {
     /// `text/html;profile=mcp-app` before mounting an iframe and
     /// avoid trusting arbitrary text the server might return for the
     /// same URI.
-    pub async fn read_resource(
-        &self,
-        uri: &str,
-    ) -> Result<(String, Option<String>, bool, bool)> {
+    pub async fn read_resource(&self, uri: &str) -> Result<(String, Option<String>, bool, bool)> {
         let result = self
             .request("resources/read", json!({ "uri": uri }))
             .await?;

--- a/crates/core/src/mcp.rs
+++ b/crates/core/src/mcp.rs
@@ -828,7 +828,10 @@ impl McpClient {
     /// `text/html;profile=mcp-app` before mounting an iframe and
     /// avoid trusting arbitrary text the server might return for the
     /// same URI.
-    pub async fn read_resource(&self, uri: &str) -> Result<(String, Option<String>, bool)> {
+    pub async fn read_resource(
+        &self,
+        uri: &str,
+    ) -> Result<(String, Option<String>, bool, bool)> {
         let result = self
             .request("resources/read", json!({ "uri": uri }))
             .await?;
@@ -849,14 +852,23 @@ impl McpClient {
                 // from its own preview origin (e.g. GamedevPreview
                 // returning an iframe whose src is the loopback HTTP
                 // server it spawned) sets `_meta.allowSameOrigin: true`.
-                // We surface it here; the trust gate at the call site
-                // decides whether to honor it.
+                // `_meta.autoSize: true` is a separate opt-in: it tells
+                // the host's McpAppIframe to honour `size-changed`
+                // notifications from the widget so DOM-based content
+                // (board games) can grow past the default 480px. Both
+                // are surfaced here; the trust gate at the call site
+                // decides whether to honor them.
                 let allow_same_origin = entry
                     .get("_meta")
                     .and_then(|m| m.get("allowSameOrigin"))
                     .and_then(Value::as_bool)
                     .unwrap_or(false);
-                return Ok((text.to_string(), mime, allow_same_origin));
+                let auto_size = entry
+                    .get("_meta")
+                    .and_then(|m| m.get("autoSize"))
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                return Ok((text.to_string(), mime, allow_same_origin, auto_size));
             }
         }
         Err(Error::Provider(format!(
@@ -1064,7 +1076,7 @@ impl Tool for McpTool {
             return None;
         }
         match self.client.read_resource(uri).await {
-            Ok((html, mime, allow_same_origin)) => Some(crate::tools::UiResource {
+            Ok((html, mime, allow_same_origin, auto_size)) => Some(crate::tools::UiResource {
                 uri: uri.to_string(),
                 html,
                 mime,
@@ -1072,6 +1084,7 @@ impl Tool for McpTool {
                 // trust check above. Untrusted servers never reach this
                 // arm so a third-party widget can never escalate.
                 allow_same_origin,
+                auto_size,
             }),
             Err(e) => {
                 eprintln!(
@@ -1619,7 +1632,7 @@ mod tests {
             .await;
         });
 
-        let (text, mime, allow_same_origin) = client
+        let (text, mime, allow_same_origin, auto_size) = client
             .read_resource("ui://pinn/image-viewer")
             .await
             .expect("read_resource");
@@ -1628,10 +1641,12 @@ mod tests {
 
         assert_eq!(text, "<html>widget</html>");
         assert_eq!(mime.as_deref(), Some("text/html;profile=mcp-app"));
-        // Default — server didn't set `_meta.allowSameOrigin`. The
-        // strict sandbox stays on; this is the safety-by-default that
-        // the allow-same-origin opt-in is layered against.
+        // Defaults — server set neither `_meta.allowSameOrigin` nor
+        // `_meta.autoSize`. The strict sandbox + fixed 480px height
+        // stay on; these are the safety-by-default the opt-in flags
+        // are layered against.
         assert!(!allow_same_origin);
+        assert!(!auto_size);
     }
 
     #[tokio::test]
@@ -1667,7 +1682,7 @@ mod tests {
             .await;
         });
 
-        let (_text, _mime, allow_same_origin) = client
+        let (_text, _mime, allow_same_origin, _auto_size) = client
             .read_resource("ui://pinn/preview")
             .await
             .expect("read_resource");

--- a/crates/core/src/tools/mod.rs
+++ b/crates/core/src/tools/mod.rs
@@ -149,6 +149,15 @@ pub struct UiResource {
     /// iframe) set it `true`; the trust is implicit because the tool
     /// ships inside the thClaws binary.
     pub allow_same_origin: bool,
+    /// First-party opt-in for content-driven inline iframe height. When
+    /// `true`, the frontend's `McpAppIframe` honours
+    /// `ui/notifications/size-changed` messages from the widget
+    /// (capped at 85% of viewport) instead of using the fixed
+    /// `INLINE_HEIGHT`. Independent from `allow_same_origin` —
+    /// sandbox policy is orthogonal to size policy, so an external
+    /// trusted server can grant same-origin without unlocking
+    /// content-driven resize and vice versa.
+    pub auto_size: bool,
 }
 
 #[derive(Default, Clone)]

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -54,6 +54,11 @@ type ChatMessage = {
     html: string;
     mime?: string;
     allowSameOrigin?: boolean;
+    /// Per-widget opt-in for content-driven inline iframe height.
+    /// Mirrors `UiResource::auto_size` in Rust + `_meta.autoSize` in
+    /// the MCP-Apps resource envelope. False / absent for everything
+    /// except first-party widgets that explicitly opted in.
+    autoSize?: boolean;
   };
 };
 
@@ -399,7 +404,13 @@ export function ChatView({ active, modalOpen }: Props) {
           // `ui/notifications/tool-result` push can carry it as a
           // standard MCP text content block.
           const ui = msg.ui_resource as
-            | { uri: string; html: string; mime?: string; allow_same_origin?: boolean }
+            | {
+                uri: string;
+                html: string;
+                mime?: string;
+                allow_same_origin?: boolean;
+                auto_size?: boolean;
+              }
             | undefined;
           const output = (msg.output as string | undefined) ?? "";
           // M6.38.9: parse `Source: <engine>` from the first line of
@@ -439,6 +450,7 @@ export function ChatView({ active, modalOpen }: Props) {
                           html: ui.html,
                           mime: ui.mime,
                           allowSameOrigin: ui.allow_same_origin === true,
+                          autoSize: ui.auto_size === true,
                         }
                       : undefined,
                     toolSource,
@@ -933,6 +945,7 @@ export function ChatView({ active, modalOpen }: Props) {
                       uri={widget.uri}
                       html={widget.html}
                       allowSameOrigin={widget.allowSameOrigin === true}
+                      autoSize={widget.autoSize === true}
                       parentToolName={msg.toolName ?? ""}
                       toolResult={{
                         content: [{ type: "text", text: msg.content }],

--- a/frontend/src/components/McpAppIframe.tsx
+++ b/frontend/src/components/McpAppIframe.tsx
@@ -87,6 +87,14 @@ type Props = {
   /// MCP-server widgets leave this `false` so they stay on an opaque
   /// origin and can't reach back into host state.
   allowSameOrigin?: boolean;
+  /// Per-widget opt-in for content-driven inline iframe height. When
+  /// `true`, `ui/notifications/size-changed` messages from the widget
+  /// resize the inline surface (capped at 85% of viewport). When
+  /// `false` (default), all such messages are silently dropped and
+  /// the iframe stays at the fixed `INLINE_HEIGHT`. Trust gate is
+  /// orthogonal to `allowSameOrigin` — a trusted widget can grant
+  /// same-origin without unlocking resize, and vice versa.
+  autoSize?: boolean;
 };
 
 type JsonRpcMessage = {
@@ -108,6 +116,13 @@ const AVAILABLE_MODES: DisplayMode[] = ["inline", "fullscreen", "pip"];
 /// lifts. A fixed 480px gives every widget a predictable canvas;
 /// content that needs more room can lift to fullscreen / PIP.
 const INLINE_HEIGHT = 480;
+/// Bounds for honored `ui/notifications/size-changed` requests. The
+/// floor avoids accidental collapse if a widget reports 0; the cap is
+/// fractional-of-viewport so an over-eager widget can't push the chat
+/// surface off-screen on a small window. Only applied when the widget
+/// opted in via `autoSize=true`.
+const AUTOSIZE_MIN = 200;
+const AUTOSIZE_MAX_FRAC = 0.85;
 
 const PIP_DEFAULT_W = 360;
 const PIP_DEFAULT_H = 260;
@@ -162,9 +177,16 @@ export function McpAppIframe({
   parentToolName,
   toolResult,
   allowSameOrigin = false,
+  autoSize = false,
 }: Props) {
   const [mode, setMode] = useState<DisplayMode>("inline");
   const [pipRect, setPipRect] = useState<PipRect>(() => loadPipRect(uri));
+  // Honored only when autoSize === true. Falls back to the fixed
+  // INLINE_HEIGHT when null (widget didn't report, isn't opted in, or
+  // reported out-of-bounds). Persists across mode toggles so a lift
+  // to fullscreen + back lands the inline surface at the same height
+  // it last measured.
+  const [measuredHeight, setMeasuredHeight] = useState<number | null>(null);
   const { resolved: themeMode } = useTheme();
 
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -493,11 +515,22 @@ export function McpAppIframe({
             });
             break;
           }
-          // ui/notifications/size-changed deliberately not handled
-          // — inline iframe height is fixed at INLINE_HEIGHT, and
-          // fullscreen / PIP have their own geometry. Falling
-          // through to the default arm is the JSON-RPC-correct
-          // response for an unhandled notification (silent drop).
+          case "ui/notifications/size-changed": {
+            // Per-widget opt-in. Untrusted / unannotated widgets keep
+            // the fixed INLINE_HEIGHT — this is the safety-by-default
+            // the autoSize flag is layered against. The pinn.ai
+            // image-viewer bug (reports spinner-state size before the
+            // image loads) is filtered out here because pinn.ai's
+            // widget meta doesn't carry autoSize.
+            if (!autoSize) break;
+            const params = msg.params as { height?: number } | undefined;
+            const h = params?.height;
+            if (typeof h !== "number" || !Number.isFinite(h)) break;
+            const cap = Math.floor(window.innerHeight * AUTOSIZE_MAX_FRAC);
+            const bounded = Math.max(AUTOSIZE_MIN, Math.min(cap, Math.ceil(h)));
+            setMeasuredHeight(bounded);
+            break;
+          }
           default:
             break;
         }
@@ -507,8 +540,10 @@ export function McpAppIframe({
     window.addEventListener("message", onMessage);
     return () => window.removeEventListener("message", onMessage);
     // themeMode is in deps so the init response uses the current theme;
-    // a re-bind is fine because we only re-bind when theme changes.
-  }, [stableResult, themeMode]);
+    // autoSize is in deps so the size-changed gate sees the current
+    // value if a future caller toggles the prop without remounting.
+    // a re-bind is fine because we only re-bind on those rare changes.
+  }, [stableResult, themeMode, autoSize]);
 
   // Clear any pending widget tool-call timers on unmount. Without
   // this, a 60s timeout could fire after the iframe is gone and
@@ -594,7 +629,7 @@ export function McpAppIframe({
       <InlineSurface
         slotRef={inlineSlotRef}
         active={mode === "inline"}
-        height={INLINE_HEIGHT}
+        height={measuredHeight ?? INLINE_HEIGHT}
         onFullscreen={() => setMode("fullscreen")}
         onPip={() => setMode("pip")}
       />


### PR DESCRIPTION
## Summary

Two coupled additions that make out-of-process MCP-Apps servers
(notably `thclaws-gamedev-mcp` over HTTP transport) usable for
in-iframe AI features:

- **Loopback `/v1/*` listener** at a fixed, documented port
  (`127.0.0.1:18443`, override via `$THCLAWS_LOOPBACK_PORT`) that
  out-of-process MCP-Apps servers can reach by convention. Auth is
  forced to `disable-auth` because safety is anchored to the loopback
  bind, not a per-launch token an external server would need to
  discover. Skipped under `--print` (short-lived) and `--serve`
  (already mounts /v1 on the user's bind).
- **Per-widget `auto_size` opt-in** carried through the MCP-Apps
  resource envelope (`_meta.autoSize`). When set, `McpAppIframe`
  honours `ui/notifications/size-changed` from the widget and grows
  the inline iframe to fit (capped at 85% of viewport). Independent
  from `allow_same_origin` — sandbox policy is orthogonal to size
  policy, so a same-origin grant doesn't imply auto-resize and vice
  versa. Untrusted / unannotated widgets keep the fixed 480px and
  silently drop size-changed messages (the original pinn.ai
  spinner-state-size bug stays filtered out).
- **`api_v1/chat.rs`** — load full `AppConfig` instead of bare
  defaults and only overwrite `model` when caller supplied a
  non-empty one. Lets widgets call `/v1/chat/completions` without
  specifying a model and route through whatever provider the user
  has authenticated in their config.

Pairs with `thclaws-gamedev-mcp@8df728d` + the follow-up auto-size
commit on that repo's `main`. End-to-end verified: thClaws +
gamedev-mcp HTTP at :8080 → `GamedevAiMove` returns the configured
provider's completion through the loopback bridge; Othello board
preview auto-resizes to fit its DOM layout.

## Test plan

- [x] `cargo build --features gui --bin thclaws` (debug + release)
- [x] `cargo test --features gui --lib api_v1::` (26 pass)
- [x] `pnpm tsc --noEmit` + `pnpm build` (frontend bundle rebuilt)
- [x] Loopback binds at `127.0.0.1:18443` after startup (verified
      via stderr log + `lsof`)
- [x] `curl http://127.0.0.1:18443/v1/models` returns model list
      without auth (disable-auth gate)
- [x] Raw MCP HTTP: initialize + tools/call `GamedevAiMove` ->
      real LLM completion through the bridge
- [x] GUI: `GamedevPreview othello-game` renders + the iframe
      auto-expands past 480px to fit the board

🤖 Generated with [Claude Code](https://claude.com/claude-code)