### PR TITLE
/cost slash + Cardputer BLE cost display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,11 +124,11 @@ dependencies = [
  "clipboard-win",
  "image 0.25.10",
  "log",
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
  "windows-sys 0.60.2",
@@ -345,11 +345,49 @@ dependencies = [
 
 [[package]]
 name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2",
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "bluez-async"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84ae4213cc2a8dc663acecac67bbdad05142be4d8ef372b6903abf878b0c690a"
+dependencies = [
+ "bitflags 2.11.1",
+ "bluez-generated",
+ "dbus",
+ "dbus-tokio",
+ "futures",
+ "itertools",
+ "log",
+ "serde",
+ "serde-xml-rs",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "bluez-generated"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9676783265eadd6f11829982792c6f303f3854d014edfba384685dcf237dd062"
+dependencies = [
+ "dbus",
 ]
 
 [[package]]
@@ -361,6 +399,34 @@ dependencies = [
  "memchr",
  "regex-automata",
  "serde",
+]
+
+[[package]]
+name = "btleplug"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9a11621cb2c8c024e444734292482b1ad86fb50ded066cf46252e46643c8748"
+dependencies = [
+ "async-trait",
+ "bitflags 2.11.1",
+ "bluez-async",
+ "dashmap 6.2.1",
+ "dbus",
+ "futures",
+ "jni 0.19.0",
+ "jni-utils",
+ "log",
+ "objc2 0.5.2",
+ "objc2-core-bluetooth",
+ "objc2-foundation 0.2.2",
+ "once_cell",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "uuid",
+ "windows",
+ "windows-future",
 ]
 
 [[package]]
@@ -879,6 +945,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,6 +983,8 @@ version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
 dependencies = [
+ "futures-channel",
+ "futures-util",
  "libc",
  "libdbus-sys",
  "windows-sys 0.61.2",
@@ -903,6 +998,17 @@ checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
 dependencies = [
  "dbus",
  "zeroize",
+]
+
+[[package]]
+name = "dbus-tokio"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007688d459bc677131c063a3a77fb899526e17b7980f390b69644bdbc41fad13"
+dependencies = [
+ "dbus",
+ "libc",
+ "tokio",
 ]
 
 [[package]]
@@ -1057,9 +1163,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -1908,6 +2014,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -2389,6 +2501,20 @@ dependencies = [
 
 [[package]]
 name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
+name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
@@ -2429,6 +2555,21 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-utils"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "259e9f2c3ead61de911f147000660511f07ab00adeed1d84f5ac4d0386e7a6c4"
+dependencies = [
+ "dashmap 5.5.3",
+ "futures",
+ "jni 0.19.0",
+ "log",
+ "once_cell",
+ "static_assertions",
+ "uuid",
 ]
 
 [[package]]
@@ -2735,15 +2876,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b2373fb763ea6962e8c586571c7f9c5d8c995f9777cbdebbe0180263691bd4b"
 dependencies = [
  "ascii",
- "block2",
+ "block2 0.6.2",
  "dirs",
  "dispatch2",
  "formatx",
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "raw-window-handle",
  "thiserror 2.0.18",
  "versions",
@@ -2906,6 +3047,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2922,11 +3079,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-bluetooth"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a644b62ffb826a5277f536cf0f701493de420b13d40e700c452c36567771111"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2937,7 +3105,7 @@ checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -2948,7 +3116,7 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.11.1",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
 ]
@@ -2970,12 +3138,24 @@ dependencies = [
 
 [[package]]
 name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -2986,7 +3166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.11.1",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -2997,9 +3177,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.1",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3009,11 +3189,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3704,15 +3884,15 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20dafead71c16a34e1ff357ddefc8afc11e7d51d6d2b9fbd07eaa48e3e540220"
 dependencies = [
- "block2",
+ "block2 0.6.2",
  "dispatch2",
  "js-sys",
  "libc",
  "log",
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "percent-encoding",
  "pollster",
  "raw-window-handle",
@@ -3938,6 +4118,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-xml-rs"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2215ce3e6a77550b80a1c37251b7d294febaf42e36e21b7b411e0bf54d540d"
+dependencies = [
+ "log",
+ "serde",
+ "thiserror 2.0.18",
+ "xml",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4160,6 +4352,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4256,7 +4454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
+ "block2 0.6.2",
  "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
@@ -4266,15 +4464,15 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
  "ndk-context",
  "ndk-sys",
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "parking_lot",
  "raw-window-handle",
@@ -4296,6 +4494,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -4329,13 +4538,14 @@ dependencies = [
 
 [[package]]
 name = "thclaws-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arboard",
  "async-stream",
  "async-trait",
  "axum",
  "base64",
+ "btleplug",
  "bytes",
  "calamine",
  "chrono",
@@ -4367,6 +4577,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tao",
+ "tar",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -4375,6 +4586,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
+ "walkdir",
  "windows-sys 0.59.0",
  "winresource",
  "wiremock",
@@ -4550,6 +4762,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -5925,7 +6149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc"
 dependencies = [
  "base64",
- "block2",
+ "block2 0.6.2",
  "cookie",
  "crossbeam-channel",
  "dirs",
@@ -5936,13 +6160,13 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-ui-kit",
  "objc2-web-kit",
  "once_cell",
@@ -5999,6 +6223,22 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "xml"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636f85e5ca6488e96401b61eb7de54f4e44755c988af0f52cf90230c312a1a89"
 
 [[package]]
 name = "yoke"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -140,9 +140,19 @@ tempfile = "3"
 # rejects.
 image = "0.24"
 
+# BLE central used by the cost_bridge module to stream session cost USD to
+# a thClaws-Cost Cardputer display. Cross-platform (CoreBluetooth on macOS,
+# zbus on Linux, WinRT on Windows). Behind a feature flag so headless CI
+# builds and the GUI-only path can opt out without pulling in BLE stacks.
+btleplug = { version = "0.11", optional = true }
+
 [features]
-default = []
+default = ["cost_bridge"]
 gui = ["dep:tao", "dep:wry", "dep:comrak", "dep:rfd", "dep:native-dialog"]
+# Cardputer cost display bridge — REPL streams session_cost_usd to a
+# thClaws-Cost peripheral over BLE NUS; device sends reset notifications
+# back when the user hits Backspace.
+cost_bridge = ["dep:btleplug"]
 
 [[bin]]
 name = "thclaws-cli"

--- a/crates/core/src/cost_bridge.rs
+++ b/crates/core/src/cost_bridge.rs
@@ -1,0 +1,183 @@
+//! BLE bridge between the thClaws REPL and a `thClaws-Cost` Cardputer
+//! display. Best-effort sidecar: the REPL keeps running even when no
+//! device is in range; the bridge silently retries connection in the
+//! background.
+//!
+//! ## Wire shape
+//!
+//! Nordic UART Service (`6e400001-…`), line-delimited JSON.
+//!
+//! - REPL → device:  `{"cost": 0.0234}`  (sent after each turn)
+//! - device → REPL:  `{"reset": true}`   (user hit Backspace / Fn+`)
+//!
+//! ## Channels
+//!
+//! - `tx_cost`  — REPL sends accumulated USD; bridge writes to NUS RX
+//! - `rx_reset` — bridge surfaces reset notifications; REPL zeros its
+//!                `session_cost_usd` in response
+//!
+//! Both are unbounded; the volumes are tiny (one event per turn).
+
+use std::time::Duration;
+
+use btleplug::api::{Central, Manager as _, Peripheral, ScanFilter, WriteType};
+use btleplug::platform::{Manager, Peripheral as PlatformPeripheral};
+use futures::stream::StreamExt;
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+// Nordic UART Service: the thClaws-Cost firmware advertises this and
+// exposes RX (writeable) + TX (notify) characteristics with these UUIDs.
+const NUS_RX_UUID: Uuid = Uuid::from_u128(0x6e400002_b5a3_f393_e0a9_e50e24dcca9e);
+const NUS_TX_UUID: Uuid = Uuid::from_u128(0x6e400003_b5a3_f393_e0a9_e50e24dcca9e);
+
+/// Local-name prefix the firmware advertises. We match any peripheral
+/// whose name starts with this so multiple devices in the same room
+/// still get picked up (the firmware suffixes with the BT MAC).
+const DEVICE_NAME_PREFIX: &str = "thClaws-Cost";
+
+/// Handle returned by [`spawn`]. Hold onto it for the lifetime of the
+/// REPL; dropping it closes the cost channel which terminates the
+/// background task on its next iteration.
+pub struct CostBridge {
+    /// Cost updates from REPL → bridge. Cloneable if you need multiple
+    /// senders; we only use one in `run_interactive` today.
+    pub tx_cost: mpsc::UnboundedSender<f64>,
+    /// Reset notifications from bridge → REPL. The REPL polls
+    /// `try_recv` once per loop iteration; we use an unbounded channel
+    /// because a missed reset would surprise the user.
+    pub rx_reset: mpsc::UnboundedReceiver<()>,
+}
+
+/// Spawn the background reconnect loop. Returns immediately. The task
+/// will keep retrying connection forever; closing `tx_cost` is the
+/// only way to terminate it.
+pub fn spawn() -> CostBridge {
+    let (tx_cost, rx_cost) = mpsc::unbounded_channel();
+    let (tx_reset, rx_reset) = mpsc::unbounded_channel();
+    tokio::spawn(run(rx_cost, tx_reset));
+    CostBridge { tx_cost, rx_reset }
+}
+
+async fn run(mut rx_cost: mpsc::UnboundedReceiver<f64>, tx_reset: mpsc::UnboundedSender<()>) {
+    // Remember the most recent cost so a fresh connection can immediately
+    // render the right number instead of $0.0000 until the next turn.
+    let mut latest_cost: f64 = 0.0;
+    let mut have_cost = false;
+
+    loop {
+        // Drain any pending cost updates that arrived while disconnected,
+        // keeping only the latest. We'll push it once we're back online.
+        while let Ok(c) = rx_cost.try_recv() {
+            latest_cost = c;
+            have_cost = true;
+        }
+        let _ = try_once(&mut rx_cost, &tx_reset, &mut latest_cost, &mut have_cost).await;
+        tokio::time::sleep(Duration::from_secs(3)).await;
+    }
+}
+
+async fn try_once(
+    rx_cost: &mut mpsc::UnboundedReceiver<f64>,
+    tx_reset: &mpsc::UnboundedSender<()>,
+    latest_cost: &mut f64,
+    have_cost: &mut bool,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let manager = Manager::new().await?;
+    let adapter = manager
+        .adapters()
+        .await?
+        .into_iter()
+        .next()
+        .ok_or("no BLE adapter")?;
+
+    adapter.start_scan(ScanFilter::default()).await?;
+
+    // Poll for a matching peripheral. 20s ceiling is long enough for
+    // most pair-on-boot scenarios; if nothing matches we fall through
+    // to the outer reconnect-wait.
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    let peripheral: PlatformPeripheral = loop {
+        if std::time::Instant::now() > deadline {
+            let _ = adapter.stop_scan().await;
+            return Err("scan timeout — no thClaws-Cost in range".into());
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let candidates = adapter.peripherals().await?;
+        let mut found: Option<PlatformPeripheral> = None;
+        for p in candidates {
+            if let Ok(Some(props)) = p.properties().await {
+                if let Some(name) = props.local_name {
+                    if name.starts_with(DEVICE_NAME_PREFIX) {
+                        found = Some(p);
+                        break;
+                    }
+                }
+            }
+        }
+        if let Some(p) = found {
+            let _ = adapter.stop_scan().await;
+            break p;
+        }
+    };
+
+    peripheral.connect().await?;
+    peripheral.discover_services().await?;
+
+    let chars = peripheral.characteristics();
+    let rx_char = chars
+        .iter()
+        .find(|c| c.uuid == NUS_RX_UUID)
+        .ok_or("NUS RX characteristic not advertised")?
+        .clone();
+    let tx_char = chars
+        .iter()
+        .find(|c| c.uuid == NUS_TX_UUID)
+        .ok_or("NUS TX characteristic not advertised")?
+        .clone();
+
+    peripheral.subscribe(&tx_char).await?;
+    let mut notif_stream = peripheral.notifications().await?;
+
+    // Push the latest cost on (re)connect so the user sees the right
+    // total even if no new turn has fired since pairing.
+    if *have_cost {
+        let _ = write_cost(&peripheral, &rx_char, *latest_cost).await;
+    }
+
+    loop {
+        tokio::select! {
+            cost = rx_cost.recv() => {
+                let Some(c) = cost else { return Ok(()); }; // REPL shutting down
+                *latest_cost = c;
+                *have_cost = true;
+                if write_cost(&peripheral, &rx_char, c).await.is_err() {
+                    return Err("write failed — peripheral likely dropped".into());
+                }
+            }
+            notif = notif_stream.next() => {
+                let Some(n) = notif else {
+                    return Err("notification stream ended".into());
+                };
+                if let Ok(s) = std::str::from_utf8(&n.value) {
+                    if s.contains("\"reset\"") {
+                        let _ = tx_reset.send(());
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn write_cost(
+    peripheral: &PlatformPeripheral,
+    rx_char: &btleplug::api::Characteristic,
+    cost: f64,
+) -> Result<(), btleplug::Error> {
+    // Six decimal places leaves headroom — display rounds to four. The
+    // float-precision overhead vs four decimals is one byte on the wire.
+    let line = format!("{{\"cost\":{:.6}}}\n", cost);
+    peripheral
+        .write(rx_char, line.as_bytes(), WriteType::WithResponse)
+        .await
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -29,6 +29,8 @@ pub mod commands;
 pub mod compaction;
 pub mod config;
 pub mod context;
+#[cfg(feature = "cost_bridge")]
+pub mod cost_bridge;
 pub mod deploy_client;
 pub mod dotenv;
 pub mod endpoints;

--- a/crates/core/src/model_catalogue.rs
+++ b/crates/core/src/model_catalogue.rs
@@ -470,6 +470,19 @@ impl EffectiveCatalogue {
         self.baseline.lookup_context(model)
     }
 
+    /// Two-tier cost computation. Tries the user cache (fresher pricing
+    /// from `/models refresh`) first, then the embedded baseline.
+    /// `None` propagates from `Catalogue::compute_cost_usd` when the
+    /// model is unpriced (e.g. tier-billed) or unknown.
+    pub fn compute_cost_usd(&self, model: &str, usage: &TokenUsage) -> Option<f64> {
+        if let Some(c) = &self.cache {
+            if let Some(cost) = c.compute_cost_usd(model, usage) {
+                return Some(cost);
+            }
+        }
+        self.baseline.compute_cost_usd(model, usage)
+    }
+
     /// Look up an override for `model`, applying the same alias and
     /// prefix-strip rules the catalogue uses. Override keys may be
     /// `provider/model` (preferred) or bare `model` — both forms are

--- a/crates/core/src/repl.rs
+++ b/crates/core/src/repl.rs
@@ -177,6 +177,12 @@ pub enum SlashCommand {
         key: String,
         value: String,
     },
+    /// Session-level cost counter shown alongside the per-turn token
+    /// line. `reset: true` zeroes the accumulator; `reset: false`
+    /// prints the current value.
+    Cost {
+        reset: bool,
+    },
     Save,
     Load(String),
     Sessions,
@@ -1334,6 +1340,13 @@ pub fn parse_slash(input: &str) -> Option<SlashCommand> {
         "cwd" | "pwd" => SlashCommand::Cwd,
         "thinking" => SlashCommand::Thinking(args.to_string()),
         "compact" => SlashCommand::Compact,
+        "cost" => match args {
+            "" => SlashCommand::Cost { reset: false },
+            "reset" | "clear" | "zero" => SlashCommand::Cost { reset: true },
+            other => SlashCommand::Unknown(format!(
+                "unknown /cost subcommand: '{other}' (try: /cost, /cost reset)"
+            )),
+        },
         "fork" => SlashCommand::Fork,
         "reload" | "restart" => SlashCommand::Reload,
         "doctor" | "diag" => SlashCommand::Doctor,
@@ -2929,6 +2942,7 @@ pub fn built_in_commands() -> &'static [BuiltInCommand] {
         BuiltInCommand { name: "version",  description: "Show version",                               category: "System", usage: "" },
         BuiltInCommand { name: "cwd",      description: "Show current working directory",             category: "System", usage: "" },
         BuiltInCommand { name: "usage",    description: "Show token usage by provider and model",     category: "System", usage: "" },
+        BuiltInCommand { name: "cost",     description: "Show or reset accumulated session cost",     category: "System", usage: "[reset]" },
         BuiltInCommand { name: "doctor",   description: "Run diagnostics",                            category: "System", usage: "" },
         BuiltInCommand { name: "config",   description: "Set a config value (session-only)",          category: "System", usage: "key=value" },
         BuiltInCommand { name: "quit",     description: "Exit",                                       category: "System", usage: "" },
@@ -3110,6 +3124,8 @@ pub fn render_help() -> &'static str {
      /version          Show version\n  \
      /team             Attach to team tmux session (or show status)\n  \
      /usage            Show token usage by provider and model\n  \
+     /cost             Show accumulated session cost in USD\n  \
+     /cost reset       Zero the session cost counter\n  \
      /skill show NAME  Show full description + path for a skill\n  \
      /skill install [--user] <url> [name]\n  \
      \x20                 Install a skill (or bundle) from a git repo or\n  \
@@ -4643,6 +4659,20 @@ pub async fn run_repl(mut config: AppConfig) -> Result<()> {
     // jobs stay in the manager until pruned, but each is announced once.
     let mut notified_research: std::collections::HashSet<String> = std::collections::HashSet::new();
 
+    // Accumulated USD cost for this REPL session. Computed via the
+    // model catalogue after every AgentEvent::Done and shown alongside
+    // the per-turn token counts. `/cost reset` zeroes it.
+    let mut session_cost_usd: f64 = 0.0;
+
+    // Cardputer cost-display bridge — best-effort BLE central that
+    // streams `session_cost_usd` to a `thClaws-Cost-*` peripheral and
+    // takes reset notifications back when the user hits Backspace on
+    // the device. Feature-gated so headless CI / GUI-only builds don't
+    // pull in btleplug. The handle stays alive for the REPL's lifetime;
+    // dropping it on Ctrl-C / quit terminates the background task.
+    #[cfg(feature = "cost_bridge")]
+    let mut cost_bridge = crate::cost_bridge::spawn();
+
     // Helper: process team inbox messages and run agent turn.
     macro_rules! process_team_messages {
         ($msgs:expr) => {{
@@ -4800,6 +4830,16 @@ pub async fn run_repl(mut config: AppConfig) -> Result<()> {
     // Uses select! to race user input against team inbox messages so the
     // lead can respond to teammates without the user needing to press Enter.
     loop {
+        // Drain Cardputer reset notifications quietly — when the user
+        // hits Backspace on the device we zero the session counter so
+        // both displays stay in sync. Silent on purpose; the device
+        // already shows the $0.0000 result and a CLI println here would
+        // garble whatever the user is mid-typing into readline.
+        #[cfg(feature = "cost_bridge")]
+        while cost_bridge.rx_reset.try_recv().is_ok() {
+            session_cost_usd = 0.0;
+        }
+
         // M6.39.2: announce any research jobs that finished since the
         // last prompt (Done / Cancelled / Failed). Each id announced
         // once; subsequent prompts skip already-notified jobs.
@@ -6414,6 +6454,23 @@ pub async fn run_repl(mut config: AppConfig) -> Result<()> {
                                 );
                             }
                         }
+                    }
+                }
+                SlashCommand::Cost { reset } => {
+                    if reset {
+                        session_cost_usd = 0.0;
+                        #[cfg(feature = "cost_bridge")]
+                        let _ = cost_bridge.tx_cost.send(0.0);
+                        println!("{COLOR_DIM}session cost reset{COLOR_RESET}");
+                    } else if session_cost_usd > 0.0 {
+                        println!(
+                            "{COLOR_DIM}session cost: ${:.4}{COLOR_RESET}",
+                            session_cost_usd
+                        );
+                    } else {
+                        println!(
+                            "{COLOR_DIM}session cost: $0.0000 (no priced turns yet){COLOR_RESET}"
+                        );
                     }
                 }
                 SlashCommand::Compact => {
@@ -8735,16 +8792,42 @@ pub async fn run_repl(mut config: AppConfig) -> Result<()> {
                         _ => String::new(),
                     };
                     let elapsed = format_duration(turn_start.elapsed());
+                    // Cost: convert provider Usage → catalogue TokenUsage
+                    // (different field names, same numbers), then look up
+                    // the active model's pricing. Unknown / tier-billed
+                    // models return None — we just skip the cost suffix.
+                    let token_usage = crate::model_catalogue::TokenUsage {
+                        prompt_tokens: usage.input_tokens,
+                        completion_tokens: usage.output_tokens,
+                        cached_input_tokens: usage.cache_read_input_tokens.unwrap_or(0),
+                        cache_creation_tokens: usage.cache_creation_input_tokens.unwrap_or(0),
+                        reasoning_tokens: usage.reasoning_output_tokens.unwrap_or(0),
+                    };
+                    let catalogue = crate::model_catalogue::EffectiveCatalogue::load();
+                    if let Some(c) = catalogue.compute_cost_usd(&config.model, &token_usage) {
+                        session_cost_usd += c;
+                    }
+                    // Push the running total to the Cardputer display.
+                    // Send fails silently when no device is paired —
+                    // we don't want a missing buddy to disrupt the REPL.
+                    #[cfg(feature = "cost_bridge")]
+                    let _ = cost_bridge.tx_cost.send(session_cost_usd);
+                    let cost_str = if session_cost_usd > 0.0 {
+                        format!(" · ${:.4} session", session_cost_usd)
+                    } else {
+                        String::new()
+                    };
                     println!(
-                        "\n{COLOR_DIM}[tokens: {}in/{}out{} · {}]{COLOR_RESET}",
-                        usage.input_tokens, usage.output_tokens, cache_info, elapsed
+                        "\n{COLOR_DIM}[tokens: {}in/{}out{} · {}{}]{COLOR_RESET}",
+                        usage.input_tokens, usage.output_tokens, cache_info, elapsed, cost_str
                     );
                     lead_log!(
-                        "\n{COLOR_DIM}[tokens: {}in/{}out{} · {}]{COLOR_RESET}\n",
+                        "\n{COLOR_DIM}[tokens: {}in/{}out{} · {}{}]{COLOR_RESET}\n",
                         usage.input_tokens,
                         usage.output_tokens,
                         cache_info,
-                        elapsed
+                        elapsed,
+                        cost_str
                     );
                     let _ = std::io::stdout().flush();
 
@@ -8876,6 +8959,26 @@ mod tests {
             Some(SlashCommand::Unknown(msg)) => assert!(msg.contains("key=value")),
             other => panic!("expected Unknown, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_slash_cost() {
+        assert_eq!(
+            parse_slash("/cost"),
+            Some(SlashCommand::Cost { reset: false })
+        );
+        assert_eq!(
+            parse_slash("/cost reset"),
+            Some(SlashCommand::Cost { reset: true })
+        );
+        assert_eq!(
+            parse_slash("/cost clear"),
+            Some(SlashCommand::Cost { reset: true })
+        );
+        assert!(matches!(
+            parse_slash("/cost bogus"),
+            Some(SlashCommand::Unknown(_))
+        ));
     }
 
     #[test]

--- a/crates/core/src/shared_session.rs
+++ b/crates/core/src/shared_session.rs
@@ -598,6 +598,17 @@ pub struct WorkerState {
     /// — without this, a `/model` swap or other rebuild would orphan
     /// the queue and any pending message would be lost.
     pub injection_queue: std::sync::Arc<std::sync::Mutex<std::collections::VecDeque<String>>>,
+    /// Running USD cost accumulator. Updated after each AgentEvent::Done
+    /// via `EffectiveCatalogue::compute_cost_usd`; surfaced through the
+    /// `/cost` slash command and pushed to the Cardputer display via
+    /// `cost_bridge`. Zeroed by `/cost reset` or by a buddy-side reset.
+    pub session_cost_usd: f64,
+    /// Optional BLE bridge to a thClaws-Cost Cardputer. `Some` whenever
+    /// the worker spawned a bridge at startup (default for both CLI and
+    /// GUI modes when the `cost_bridge` feature is on); `None` when the
+    /// feature is compiled out so the field is harmless to reference.
+    #[cfg(feature = "cost_bridge")]
+    pub cost_bridge: Option<crate::cost_bridge::CostBridge>,
 }
 
 /// M6.29: handle to a running `/loop` task.
@@ -1554,6 +1565,9 @@ async fn run_worker(
         line_session: None,
         line_pre_mode: None,
         line_pre_approver: None,
+        session_cost_usd: 0.0,
+        #[cfg(feature = "cost_bridge")]
+        cost_bridge: Some(crate::cost_bridge::spawn()),
     };
 
     // M6.35 HOOK2: fire session_start hook now that WorkerState is
@@ -3257,6 +3271,33 @@ async fn drive_turn_stream(
                 let tracker =
                     crate::usage::UsageTracker::new(crate::usage::UsageTracker::default_path());
                 tracker.record(provider_name, &state.config.model, &usage);
+
+                // Cost accounting (GUI parity with the CLI REPL). Drain
+                // any pending buddy resets first so a mid-turn Backspace
+                // on the Cardputer takes effect before this turn's
+                // contribution lands. Then accumulate, then push the new
+                // total to the buddy if a bridge is attached.
+                #[cfg(feature = "cost_bridge")]
+                if let Some(ref mut bridge) = state.cost_bridge {
+                    while bridge.rx_reset.try_recv().is_ok() {
+                        state.session_cost_usd = 0.0;
+                    }
+                }
+                let token_usage = crate::model_catalogue::TokenUsage {
+                    prompt_tokens: usage.input_tokens,
+                    completion_tokens: usage.output_tokens,
+                    cached_input_tokens: usage.cache_read_input_tokens.unwrap_or(0),
+                    cache_creation_tokens: usage.cache_creation_input_tokens.unwrap_or(0),
+                    reasoning_tokens: usage.reasoning_output_tokens.unwrap_or(0),
+                };
+                let catalogue = crate::model_catalogue::EffectiveCatalogue::load();
+                if let Some(c) = catalogue.compute_cost_usd(&state.config.model, &token_usage) {
+                    state.session_cost_usd += c;
+                }
+                #[cfg(feature = "cost_bridge")]
+                if let Some(ref bridge) = state.cost_bridge {
+                    let _ = bridge.tx_cost.send(state.session_cost_usd);
+                }
 
                 // If a skill applied a model override this turn, emit
                 // a revert chat note so the user sees the active

--- a/crates/core/src/shell_dispatch.rs
+++ b/crates/core/src/shell_dispatch.rs
@@ -780,6 +780,26 @@ pub async fn dispatch(
                 format!("(session-only) {key} = {value} — applied to runtime only; edit .thclaws/settings.json for persistence"),
             );
         }
+        SlashCommand::Cost { reset } => {
+            if reset {
+                state.session_cost_usd = 0.0;
+                #[cfg(feature = "cost_bridge")]
+                if let Some(ref bridge) = state.cost_bridge {
+                    let _ = bridge.tx_cost.send(0.0);
+                }
+                emit(events_tx, "session cost reset".into());
+            } else if state.session_cost_usd > 0.0 {
+                emit(
+                    events_tx,
+                    format!("session cost: ${:.4}", state.session_cost_usd),
+                );
+            } else {
+                emit(
+                    events_tx,
+                    "session cost: $0.0000 (no priced turns yet)".into(),
+                );
+            }
+        }
         SlashCommand::Compact => {
             let history = state.agent.history_snapshot();
             let compacted = crate::compaction::compact(&history, state.agent.budget_tokens / 2);


### PR DESCRIPTION
## Summary

- New `/cost` (and `/cost reset`) slash command — CLI + GUI parity. Bare `/cost` prints the running USD total; subcommands zero the accumulator.
- Per-turn `· $X.XXXX session` suffix on the CLI tokens line (silently skipped for tier-billed / unknown models).
- Optional **BLE bridge** (feature `cost_bridge`, default on) that streams the running cost to a paired M5Stack Cardputer running the `thClaws-Cost` firmware. Backspace on the device sends a reset notification back, zeroing both sides and triggering a 3-sec logo replay on the device.
- New `btleplug = "0.11"` dep (cross-platform BLE: CoreBluetooth/zbus/WinRT — no system packages required). Behind a feature flag so `--no-default-features` builds skip it cleanly.

Internals worth a glance:
- `EffectiveCatalogue::compute_cost_usd` — new two-tier helper (user cache → embedded baseline). Underlying `Catalogue::compute_cost_usd` math is untouched.
- CLI keeps `session_cost_usd` in `run_interactive`'s locals.
- GUI threads it through `WorkerState` so the worker, `shell_dispatch.rs` `/cost` arm, and `drive_turn_stream`'s Done handler all see the same field.

## Test plan

- [ ] `cargo build` (default features) succeeds
- [ ] `cargo build --no-default-features` succeeds (no btleplug)
- [ ] `cargo build --features gui` succeeds
- [ ] `cargo test parse_slash_cost` passes
- [ ] `cargo fmt --all -- --check` clean
- [ ] CLI: type `/cost` after a turn → prints `$X.XXXX`
- [ ] CLI: `/cost reset` zeros the counter
- [ ] CLI: tokens line shows `· \$X.XXXX session` suffix for priced models
- [ ] GUI: `/cost` slash works in chat input
- [ ] (Hardware) Pair a Cardputer flashed with `thClaws-Cost` → see live cost on device → Backspace resets host

🤖 Generated with [Claude Code](https://claude.com/claude-code)