### PR TITLE
fix(cli): make --model flag work across CLI, GUI, and serve modes

### DIFF
--- a/crates/core/src/bin/app.rs
+++ b/crates/core/src/bin/app.rs
@@ -337,6 +337,15 @@ async fn main() {
     // exists or if a Claude Code `.claude/settings.json` is present.
     thclaws_core::config::ProjectConfig::ensure_default_exists();
 
+    // If --model was passed, persist it to .thclaws/settings.json so
+    // GUI, serve, and CLI all see the same model without needing
+    // per-mode override plumbing.
+    if let Some(ref m) = cli.model {
+        let mut project = thclaws_core::config::ProjectConfig::load().unwrap_or_default();
+        project.set_model(&thclaws_core::providers::ProviderKind::resolve_alias(m));
+        let _ = project.save();
+    }
+
     // In-process scheduler (Step 2): spawn a background tokio task
     // that polls `~/.config/thclaws/schedules.json` every 30s and
     // fires due jobs as `thclaws --print` subprocesses. Skipped for


### PR DESCRIPTION
The --model CLI override was only applied in the CLI/REPL branch (bin/app.rs:448) after the GUI and serve modes had already returned. This meant --model was silently ignored when running the GUI or standalone server.

Fix: persist the --model value into .thclaws/settings.json early, before any mode dispatch. All modes (CLI, GUI, --serve, --gui) subsequently load the model from the same project-level config file.

- Moved the override logic to run right after first-run bootstrap and before serve/gui/CLI branching.
- No signature changes needed in gui.rs, server.rs, or repl.rs.

## Summary

Briefly describe what this PR does.

## Motivation

Why is this change needed? Link the issue it closes (e.g. `Closes #123`).

## Changes

- ...
- ...

## Test plan

How did you verify this works?

- [ ] `cargo test --features gui` passes locally
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --features gui -- -D warnings` passes
- [ ] Frontend type-check passes (`cd frontend && pnpm tsc --noEmit`) — if frontend touched
- [ ] Manually exercised the feature — steps:
  1. ...
  2. ...

## Screenshots / recordings

For GUI / CLI UX changes, include a before / after screenshot or short recording.

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if behavior changes (README / CHANGELOG / in-repo docs)
- [ ] No new compiler warnings introduced
- [ ] PR scope is focused — no unrelated changes
- [ ] Commits follow project style (concise, imperative, optional `feat/fix/docs/...` prefix)
