### PR TITLE
fix(agent): pop partial assistant on max_tokens escalation retry

### DIFF
--- a/crates/core/src/agent.rs
+++ b/crates/core/src/agent.rs
@@ -1306,6 +1306,21 @@ impl Agent {
                         // Anthropic rejects any user message with empty
                         // content ("messages.N: user messages must have
                         // non-empty content").
+                        // Pop the partial assistant we just pushed at the
+                        // top of this block. The retry re-asks with a
+                        // larger token budget and the model produces a
+                        // fresh complete response — leaving the partial
+                        // in history would make the next provider.stream
+                        // call's messages end with role=assistant, which
+                        // claude-opus-4-7+ rejects ("This model does not
+                        // support assistant message prefill. The
+                        // conversation must end with a user message.").
+                        {
+                            let mut h = history.lock().expect("history lock");
+                            if h.last().map(|m| m.role) == Some(Role::Assistant) {
+                                h.pop();
+                            }
+                        }
                         continue;
                     } else {
                         // Clear any skill-recommended model override


### PR DESCRIPTION
When the model hits stop_reason=max_tokens with no tool_uses, the loop escalates max_tokens to 64000 and retries the same turn. The partial assistant message was already pushed to history, so the retry's provider.stream call ended messages with role=assistant — which claude-opus-4-7 rejects ("This model does not support assistant message prefill. The conversation must end with a user message.").

Pop the assistant message before continuing so the next iteration's request ends with a user role. The model re-produces a complete response with the larger budget.

## Screenshots / recordings

Before the fix:
<img width="977" height="378" alt="image" src="https://github.com/user-attachments/assets/227001b0-ca92-4953-a5fe-d2b8ac6ce9ab" />

After fix:
<img width="667" height="247" alt="image" src="https://github.com/user-attachments/assets/e0a1620d-8f43-4327-bc32-63fe2bc90ae8" />

