### PR TITLE
fix(macos): make cost_bridge opt-in, not default — fixes startup SIGABRT (#116)

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -147,11 +147,18 @@ image = "0.24"
 btleplug = { version = "0.11", optional = true }
 
 [features]
-default = ["cost_bridge"]
+# `cost_bridge` is OPT-IN, not default: it starts a BLE scan on launch
+# (cost_bridge::spawn → adapter.start_scan), which on macOS triggers a
+# TCC SIGABRT for any binary without an NSBluetoothAlwaysUsageDescription
+# Info.plist — i.e. every `cargo build` and every GitHub release archive
+# (no .app bundle). It also pops a Bluetooth permission prompt for the
+# ~99% of users who don't own a thClaws-Cost Cardputer. Cardputer users
+# build with `--features cost_bridge`. Issue #116.
+default = []
 gui = ["dep:tao", "dep:wry", "dep:comrak", "dep:rfd", "dep:native-dialog"]
 # Cardputer cost display bridge — REPL streams session_cost_usd to a
 # thClaws-Cost peripheral over BLE NUS; device sends reset notifications
-# back when the user hits Backspace.
+# back when the user hits Backspace. Opt-in (see note on `default`).
 cost_bridge = ["dep:btleplug"]
 
 [[bin]]


### PR DESCRIPTION
Closes #116. Thanks @ultramcu for the precise diagnosis + the proof-by-workaround.

## The bug

`cost_bridge::spawn()` (`crates/core/src/cost_bridge.rs:55`) starts a BLE scan on launch — `adapter.start_scan()` at line 94, called unconditionally from `repl.rs` and `shared_session.rs` when a session starts. On macOS, any binary **without** an `NSBluetoothAlwaysUsageDescription` Info.plist gets killed by **TCC** with a hard **SIGABRT** ~1–3s after startup, before serving any request. That's every `cargo build` binary **and every GitHub release archive** (none are `.app` bundles).

Because `cost_bridge` is in `default = [...]` and the release workflow builds `--features gui` (`.github/workflows/release.yml:133`), **all v0.15.0 + v0.16.0 macOS release binaries crash on launch**, not just source builds.

Secondary problem: even when it doesn't crash, every user gets a Bluetooth permission prompt + background BLE scan despite ~99% not owning a thClaws-Cost Cardputer.

## The fix

```diff
-default = ["cost_bridge"]
+default = []
```

Cardputer users opt in with `--features cost_bridge`. No code changes needed — the call sites are already `#[cfg(feature = "cost_bridge")]`-gated, so a default build never links `btleplug` or starts the scan.

Not taking the "embed Info.plist" alternative: it's a higher-risk binary-layout change, doesn't fix the spurious permission prompt, and is unnecessary once the bridge is opt-in.

## Test plan

- [x] `cargo build --features gui --bin thclaws` (default, cost_bridge OFF) — builds clean
- [x] `cargo build --bin thclaws-cli` — builds clean
- [x] `cargo build --features gui,cost_bridge --bin thclaws` (Cardputer opt-in) — builds clean
- [x] `cargo fmt --all -- --check`
- [ ] **macOS smoke (maintainer / @ultramcu):** `cargo build --features gui --bin thclaws && ./target/debug/thclaws --serve --port 8443` → stays up, `curl localhost:8443` returns 200, no SIGABRT

## Follow-up (not in this PR)

- Cut **v0.16.1** with this fix; old v0.15.0/v0.16.0 macOS artifacts stay as-is with a note pointing here.
- Cardputer build docs / dev-log to mention the `--features cost_bridge` opt-in.