### PR TITLE
fix(mcp): headers in /mcp add, probe/discovery timeouts, non-blocking add, ${VAR} (#114)

### DIFF
--- a/crates/core/src/mcp.rs
+++ b/crates/core/src/mcp.rs
@@ -566,7 +566,9 @@ impl McpClient {
 
         // Bridge task: read JSON-RPC lines from client_write side, POST
         // each to the HTTP URL, write the response body back to server_write.
-        // On 401, attempt OAuth discovery + browser flow, then retry.
+        // On 401, attempt OAuth discovery + browser flow, then retry —
+        // UNLESS this is a non-interactive connect (`/mcp add`), in which
+        // case we fail the request fast instead of popping a browser.
         tokio::spawn(async move {
             use tokio::io::{AsyncBufReadExt, BufReader};
             let mut reader = BufReader::new(server_read);
@@ -638,6 +640,39 @@ impl McpClient {
                             hdrs.chars().take(300).collect::<String>(),
                             body_preview.chars().take(300).collect::<String>(),
                         );
+                        // Non-interactive connect (`/mcp add`): never open a
+                        // browser. The upfront probe can't catch a server
+                        // that lets `ping` through unauthenticated but 401s
+                        // on `initialize`, so guard here too. Fail the
+                        // pending request fast with a JSON-RPC error (echoing
+                        // the numeric id so `handle_incoming` matches it) —
+                        // `initialize()` returns promptly and `/mcp add`
+                        // reports "run /mcp reauth" instead of hanging on a
+                        // browser callback. Issue #114.
+                        if !interactive_oauth {
+                            eprintln!(
+                                "\x1b[33m[mcp-http] {name_for_task}: server requires OAuth — run `/mcp reauth {name_for_task}`\x1b[0m"
+                            );
+                            if let Some(id) = serde_json::from_str::<Value>(trimmed)
+                                .ok()
+                                .and_then(|v| v.get("id").and_then(Value::as_u64))
+                            {
+                                let synthetic = json!({
+                                    "jsonrpc": "2.0",
+                                    "id": id,
+                                    "error": {
+                                        "code": -32001,
+                                        "message": format!(
+                                            "{name_for_task}: server requires OAuth — run /mcp reauth {name_for_task}"
+                                        ),
+                                    },
+                                })
+                                .to_string();
+                                write_body_to_pipe(&mut writer, &synthetic, "application/json")
+                                    .await;
+                            }
+                            continue;
+                        }
                         // Invalidate so resolve_oauth_token doesn't just
                         // return the same rejected token from the store.
                         {
@@ -2208,7 +2243,10 @@ mod tests {
         };
         // Braced var resolves.
         assert_eq!(interpolate_with("${FD_KEY}", env), "secret123");
-        assert_eq!(interpolate_with("Bearer ${FD_KEY}", env), "Bearer secret123");
+        assert_eq!(
+            interpolate_with("Bearer ${FD_KEY}", env),
+            "Bearer secret123"
+        );
         // Multiple vars in one value.
         assert_eq!(interpolate_with("${A}-${B}", env), "aa-bb");
         // Unset var → literal preserved (visible misconfig, not silent empty).
@@ -2232,18 +2270,24 @@ mod tests {
         let server_ok = MockServer::start().await;
         Mock::given(method("POST"))
             .and(header("x-api-key", "secret123"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(
-                r#"{"jsonrpc":"2.0","id":0,"result":{}}"#,
-            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(r#"{"jsonrpc":"2.0","id":0,"result":{}}"#),
+            )
             .mount(&server_ok)
             .await;
 
         let mut headers = HashMap::new();
         headers.insert("X-API-KEY".to_string(), "secret123".to_string());
         // interactive flag irrelevant when auth succeeds.
-        let res =
-            resolve_token_upfront(&reqwest::Client::new(), &server_ok.uri(), "t", &headers, false)
-                .await;
+        let res = resolve_token_upfront(
+            &reqwest::Client::new(),
+            &server_ok.uri(),
+            "t",
+            &headers,
+            false,
+        )
+        .await;
         assert!(
             matches!(res, UpfrontToken::Proceed(None)),
             "header-authed probe should Proceed with no bearer token",
@@ -2281,9 +2325,7 @@ mod tests {
 
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .respond_with(
-                ResponseTemplate::new(200).set_delay(Duration::from_secs(10)),
-            )
+            .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(10)))
             .mount(&server)
             .await;
 
@@ -2293,8 +2335,7 @@ mod tests {
             .unwrap();
 
         let started = std::time::Instant::now();
-        let res =
-            resolve_token_upfront(&client, &server.uri(), "t", &HashMap::new(), false).await;
+        let res = resolve_token_upfront(&client, &server.uri(), "t", &HashMap::new(), false).await;
         let elapsed = started.elapsed();
         // Probe errored (timeout) → we proceed without a token, fast.
         assert!(
@@ -2304,6 +2345,64 @@ mod tests {
         assert!(
             elapsed < Duration::from_secs(3),
             "probe must not hang on a stalled server; took {elapsed:?}",
+        );
+    }
+
+    // ── Fix 3 (deep): a server that lets `ping` through but 401s on
+    //    `initialize` must NOT trigger the browser flow in a
+    //    non-interactive `/mcp add` — the bridge fails the request fast.
+    //    This is the gap the upfront probe alone can't catch.
+    #[tokio::test]
+    async fn noninteractive_connect_defers_when_initialize_401s() {
+        use wiremock::matchers::{body_string_contains, method};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        // Probe `ping` is allowed through unauthenticated (200).
+        Mock::given(method("POST"))
+            .and(body_string_contains("\"method\":\"ping\""))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(r#"{"jsonrpc":"2.0","id":0,"result":{}}"#),
+            )
+            .mount(&server)
+            .await;
+        // …but `initialize` requires auth → 401.
+        Mock::given(method("POST"))
+            .and(body_string_contains("\"method\":\"initialize\""))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+
+        let cfg = McpServerConfig {
+            name: "fd".into(),
+            transport: "http".into(),
+            command: String::new(),
+            args: Vec::new(),
+            env: Default::default(),
+            url: server.uri(),
+            headers: Default::default(),
+            trusted: false,
+        };
+
+        let started = std::time::Instant::now();
+        let res = McpClient::spawn_noninteractive(cfg, None).await;
+        let elapsed = started.elapsed();
+
+        assert!(
+            res.is_err(),
+            "initialize 401 must fail the connect, not succeed"
+        );
+        let msg = format!("{}", res.err().unwrap());
+        assert!(
+            msg.contains("reauth") || msg.contains("OAuth"),
+            "error should point the user at /mcp reauth; got: {msg}",
+        );
+        // Must NOT have blocked on a browser callback (5 min) or even the
+        // 30s request timeout — the synthetic error returns immediately.
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "non-interactive connect must fail fast on initialize 401; took {elapsed:?}",
         );
     }
 }

--- a/crates/core/src/mcp.rs
+++ b/crates/core/src/mcp.rs
@@ -414,6 +414,25 @@ impl McpClient {
         Self::spawn_with_approver(config, None).await
     }
 
+    /// Like [`spawn_with_approver`] but never launches the interactive
+    /// OAuth browser flow for HTTP servers. Used by `/mcp add` (CLI and
+    /// GUI): an HTTP server that requires OAuth returns an error telling
+    /// the user to run `/mcp reauth <name>` instead of freezing the
+    /// command (CLI) or the worker thread (GUI) for up to 5 minutes
+    /// waiting on a browser callback the user may not be ready for
+    /// (issue #114). stdio transport is unaffected — it still goes
+    /// through `spawn_with_approver` with the caller's approver, so the
+    /// command-allowlist gate keeps working in GUI mode.
+    pub async fn spawn_noninteractive(
+        config: McpServerConfig,
+        approver: Option<Arc<dyn crate::permissions::ApprovalSink>>,
+    ) -> Result<Arc<Self>> {
+        if config.transport == "http" {
+            return Self::connect_http(config, false).await;
+        }
+        Self::spawn_with_approver(config, approver).await
+    }
+
     /// Same as [`spawn`] but lets the caller provide an `ApprovalSink`
     /// for the first-time spawn prompt. GUI mode passes its
     /// `GuiApprover` here so MCP approval pops up in the same modal as
@@ -424,7 +443,7 @@ impl McpClient {
         approver: Option<Arc<dyn crate::permissions::ApprovalSink>>,
     ) -> Result<Arc<Self>> {
         if config.transport == "http" {
-            return Self::connect_http(config).await;
+            return Self::connect_http(config, true).await;
         }
 
         // Allowlist gate: MCP stdio configs come from project-scoped
@@ -466,7 +485,7 @@ impl McpClient {
     /// HTTP POST → JSON response. We simulate the stream pair by piping
     /// through an in-memory duplex so the rest of the client (reader task,
     /// pending map) works unchanged.
-    async fn connect_http(config: McpServerConfig) -> Result<Arc<Self>> {
+    async fn connect_http(config: McpServerConfig, interactive_oauth: bool) -> Result<Arc<Self>> {
         if config.url.is_empty() {
             return Err(Error::Provider(format!(
                 "mcp http server '{}': missing 'url' field",
@@ -481,7 +500,15 @@ impl McpClient {
 
         let url = config.url.clone();
         let name_for_task = config.name.clone();
-        let extra_headers = config.headers.clone();
+        // Interpolate `${VAR}` in header values from the environment so a
+        // secret (API key, bearer token) can live in the shell / `.env`
+        // instead of plaintext in mcp.json. Resolved once here; both the
+        // auth probe and every bridge POST use this map.
+        let extra_headers: HashMap<String, String> = config
+            .headers
+            .iter()
+            .map(|(k, v)| (k.clone(), interpolate_env(v)))
+            .collect();
         // Disable auto-redirects: reqwest strips the Authorization header on
         // ALL redirects (even same-origin 307). Our `write_response_lines`
         // handles 307/308 manually, preserving auth + fixing http→https.
@@ -497,12 +524,34 @@ impl McpClient {
         //   2. Try refresh if expired.
         //   3. Probe the server → if 401, run full OAuth browser flow.
         //   4. Only then set up the bridge with the token already loaded.
+        // Probe + discovery get hard timeouts so a stalled server can't
+        // hang `/mcp add` (or a startup spawn) forever. The bridge
+        // `http_client` above deliberately has NO blanket timeout — it
+        // carries streaming SSE responses, and per-request deadlines are
+        // enforced separately by REQUEST_TIMEOUT_SECS in `request()`.
         let http_probe = reqwest::Client::builder()
             .redirect(reqwest::redirect::Policy::none())
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(15))
             .build()
             .unwrap_or_else(|_| reqwest::Client::new());
-        let resolved_token =
-            resolve_token_upfront(&http_probe, &url, &config.name, &config.headers).await;
+        let resolved_token = match resolve_token_upfront(
+            &http_probe,
+            &url,
+            &config.name,
+            &extra_headers,
+            interactive_oauth,
+        )
+        .await
+        {
+            UpfrontToken::Proceed(tok) => tok,
+            UpfrontToken::OAuthRequired => {
+                return Err(Error::Provider(format!(
+                    "MCP server '{}' requires OAuth — run `/mcp reauth {}` to authenticate (opens a browser)",
+                    config.name, config.name
+                )));
+            }
+        };
 
         let token: std::sync::Arc<tokio::sync::Mutex<Option<String>>> =
             std::sync::Arc::new(tokio::sync::Mutex::new(resolved_token));
@@ -1245,12 +1294,69 @@ async fn write_response_lines(
 /// Pre-resolve an OAuth token before the bridge task starts. Runs the
 /// full discovery + browser flow if needed so the bridge never blocks on
 /// OAuth during the time-sensitive MCP initialize handshake.
+/// Substitute `${VAR}` occurrences in `s` with the corresponding
+/// environment variable. Used on MCP header values so a secret can be
+/// stored as `"X-API-KEY": "${MY_KEY}"` in mcp.json and resolved from
+/// the environment (or `.env`, already loaded into the process env at
+/// startup) at connection time — keeping the literal secret out of the
+/// committed config. An unset variable is left as the literal `${VAR}`
+/// so the misconfiguration is visible (a bogus header → a diagnosable
+/// 401) rather than silently sent as an empty value. `$VAR` without
+/// braces is intentionally NOT expanded — header values legitimately
+/// contain bare `$`.
+fn interpolate_env(s: &str) -> String {
+    interpolate_with(s, |k| std::env::var(k).ok())
+}
+
+/// Core of [`interpolate_env`], parametrized on the variable lookup so
+/// it's testable without mutating process env (which races with the
+/// `posix_spawn` in the scheduler tests under the parallel runner).
+fn interpolate_with(s: &str, lookup: impl Fn(&str) -> Option<String>) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(start) = rest.find("${") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + 2..];
+        if let Some(end) = after.find('}') {
+            let var = &after[..end];
+            match lookup(var) {
+                Some(val) => out.push_str(&val),
+                // Unset → keep the literal `${VAR}` for visibility.
+                None => {
+                    out.push_str("${");
+                    out.push_str(var);
+                    out.push('}');
+                }
+            }
+            rest = &after[end + 1..];
+        } else {
+            // No closing brace — emit the rest verbatim and stop.
+            out.push_str(&rest[start..]);
+            return out;
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Outcome of the upfront auth probe in [`McpClient::connect_http`].
+enum UpfrontToken {
+    /// Proceed to build the bridge with this optional bearer token.
+    Proceed(Option<String>),
+    /// Server demands OAuth and the caller asked us NOT to run the
+    /// interactive browser flow (`/mcp add`). The caller bails with a
+    /// "run /mcp reauth" message instead of blocking on a browser
+    /// callback. Issue #114.
+    OAuthRequired,
+}
+
 async fn resolve_token_upfront(
     client: &reqwest::Client,
     mcp_url: &str,
     server_name: &str,
     extra_headers: &HashMap<String, String>,
-) -> Option<String> {
+    interactive: bool,
+) -> UpfrontToken {
     let mut store = crate::oauth::TokenStore::load();
 
     // Try cached token (or refreshed) — but ALWAYS verify against the
@@ -1302,6 +1408,12 @@ async fn resolve_token_upfront(
                 mcp_debug!("\x1b[33m[mcp-http] {server_name}: token rejected (401)\x1b[0m");
                 store.remove(mcp_url);
             }
+            if !interactive {
+                // `/mcp add`: don't pop a browser mid-command. Signal the
+                // caller to save the server and defer to `/mcp reauth`.
+                mcp_debug!("\x1b[36m[mcp-http] {server_name}: OAuth required (non-interactive — deferring)\x1b[0m");
+                return UpfrontToken::OAuthRequired;
+            }
             // KEEP this on by default — a browser window is about to
             // pop up and the user needs to know why.
             eprintln!("\x1b[36m[mcp-http] {server_name}: server requires OAuth — starting browser flow…\x1b[0m");
@@ -1309,16 +1421,16 @@ async fn resolve_token_upfront(
         Ok(r) => {
             let status = r.status();
             mcp_debug!("\x1b[2m[mcp-http] {server_name}: probe → {status} (auth OK)\x1b[0m");
-            return candidate;
+            return UpfrontToken::Proceed(candidate);
         }
         Err(e) => {
             eprintln!("\x1b[33m[mcp-http] {server_name}: probe failed ({e})\x1b[0m");
-            return candidate;
+            return UpfrontToken::Proceed(candidate);
         }
     }
 
-    // Full OAuth discovery + browser flow.
-    resolve_oauth_token(client, mcp_url, server_name).await
+    // Full OAuth discovery + browser flow (interactive callers only).
+    UpfrontToken::Proceed(resolve_oauth_token(client, mcp_url, server_name).await)
 }
 
 /// Try to get a valid OAuth token for an MCP URL:
@@ -2079,6 +2191,119 @@ mod tests {
         assert!(
             msg.contains("transport closed"),
             "expected 'transport closed', got: {msg}",
+        );
+    }
+
+    // ── Fix 4: header ${VAR} interpolation (issue #114) ──────────────
+    // Closure-injected lookup so no process env is mutated (which would
+    // race with the scheduler tests' posix_spawn under the parallel
+    // runner — see config.rs TEST_ENV_LOCK note).
+    #[test]
+    fn interpolate_with_resolves_braced_vars_only() {
+        let env = |k: &str| match k {
+            "FD_KEY" => Some("secret123".to_string()),
+            "A" => Some("aa".to_string()),
+            "B" => Some("bb".to_string()),
+            _ => None,
+        };
+        // Braced var resolves.
+        assert_eq!(interpolate_with("${FD_KEY}", env), "secret123");
+        assert_eq!(interpolate_with("Bearer ${FD_KEY}", env), "Bearer secret123");
+        // Multiple vars in one value.
+        assert_eq!(interpolate_with("${A}-${B}", env), "aa-bb");
+        // Unset var → literal preserved (visible misconfig, not silent empty).
+        assert_eq!(interpolate_with("${MISSING}", env), "${MISSING}");
+        // Bare $ is NOT expanded (header values legitimately contain `$`).
+        assert_eq!(interpolate_with("$FD_KEY", env), "$FD_KEY");
+        // No interpolation token.
+        assert_eq!(interpolate_with("plain-value", env), "plain-value");
+        // Unterminated brace → emitted verbatim, no panic.
+        assert_eq!(interpolate_with("${oops", env), "${oops");
+    }
+
+    // ── Fix 1 + Fix 3: probe sends configured headers; non-interactive
+    //    401 defers to OAuth instead of blocking. Wiremock — no real API.
+    #[tokio::test]
+    async fn probe_sends_headers_and_defers_oauth_when_noninteractive() {
+        use wiremock::matchers::{header, method};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // Server A: requires X-API-KEY. Probe ping with the header → 200.
+        let server_ok = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(header("x-api-key", "secret123"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"{"jsonrpc":"2.0","id":0,"result":{}}"#,
+            ))
+            .mount(&server_ok)
+            .await;
+
+        let mut headers = HashMap::new();
+        headers.insert("X-API-KEY".to_string(), "secret123".to_string());
+        // interactive flag irrelevant when auth succeeds.
+        let res =
+            resolve_token_upfront(&reqwest::Client::new(), &server_ok.uri(), "t", &headers, false)
+                .await;
+        assert!(
+            matches!(res, UpfrontToken::Proceed(None)),
+            "header-authed probe should Proceed with no bearer token",
+        );
+
+        // Server B: always 401 (no/By-wrong key). Non-interactive → must
+        // return OAuthRequired (defer to /mcp reauth), NOT block/try browser.
+        let server_401 = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server_401)
+            .await;
+        let res = resolve_token_upfront(
+            &reqwest::Client::new(),
+            &server_401.uri(),
+            "t",
+            &HashMap::new(),
+            false, // non-interactive (= /mcp add)
+        )
+        .await;
+        assert!(
+            matches!(res, UpfrontToken::OAuthRequired),
+            "non-interactive 401 must defer to OAuth, not block",
+        );
+    }
+
+    // ── Fix 2: a stalled server can't hang the probe — the client
+    //    timeout converts it to a prompt "proceed without token" rather
+    //    than an indefinite hang. Uses a short test timeout to prove the
+    //    mechanism (production uses 15s, verified by reading connect_http).
+    #[tokio::test]
+    async fn probe_timeout_does_not_hang() {
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(200).set_delay(Duration::from_secs(10)),
+            )
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(300))
+            .build()
+            .unwrap();
+
+        let started = std::time::Instant::now();
+        let res =
+            resolve_token_upfront(&client, &server.uri(), "t", &HashMap::new(), false).await;
+        let elapsed = started.elapsed();
+        // Probe errored (timeout) → we proceed without a token, fast.
+        assert!(
+            matches!(res, UpfrontToken::Proceed(None)),
+            "timed-out probe should proceed without a token",
+        );
+        assert!(
+            elapsed < Duration::from_secs(3),
+            "probe must not hang on a stalled server; took {elapsed:?}",
         );
     }
 }

--- a/crates/core/src/oauth.rs
+++ b/crates/core/src/oauth.rs
@@ -261,7 +261,11 @@ pub async fn discover(client: &Client, mcp_url: &str) -> Result<OAuthMetadata> {
             .map_err(|e| Error::Provider(format!("oauth server metadata json: {e}")))
     })
     .await
-    .map_err(|_| Error::Provider(format!("oauth server metadata: timed out fetching {meta_url} (15s)")))??;
+    .map_err(|_| {
+        Error::Provider(format!(
+            "oauth server metadata: timed out fetching {meta_url} (15s)"
+        ))
+    })??;
 
     let authorization_endpoint = meta
         .get("authorization_endpoint")

--- a/crates/core/src/oauth.rs
+++ b/crates/core/src/oauth.rs
@@ -215,15 +215,25 @@ pub async fn discover(client: &Client, mcp_url: &str) -> Result<OAuthMetadata> {
     let resource_meta_url = format!("{origin}/.well-known/oauth-protected-resource");
     eprintln!("\x1b[2m[oauth] fetching {resource_meta_url}\x1b[0m");
 
-    let resource_resp = client
-        .get(&resource_meta_url)
-        .send()
-        .await
-        .map_err(|e| Error::Provider(format!("oauth discovery: {e}")))?;
-    let resource: Value = resource_resp
-        .json()
-        .await
-        .map_err(|e| Error::Provider(format!("oauth resource metadata: {e}")))?;
+    // Hard timeout so a stalled/black-holed discovery endpoint can't hang
+    // the caller (`/mcp add`, a startup spawn) indefinitely. Wraps both
+    // the connect+send and the body read.
+    let resource: Value = tokio::time::timeout(std::time::Duration::from_secs(15), async {
+        let resp = client
+            .get(&resource_meta_url)
+            .send()
+            .await
+            .map_err(|e| Error::Provider(format!("oauth discovery: {e}")))?;
+        resp.json::<Value>()
+            .await
+            .map_err(|e| Error::Provider(format!("oauth resource metadata: {e}")))
+    })
+    .await
+    .map_err(|_| {
+        Error::Provider(format!(
+            "oauth discovery: timed out fetching {resource_meta_url} (15s)"
+        ))
+    })??;
 
     let auth_server = resource
         .get("authorization_servers")
@@ -240,15 +250,18 @@ pub async fn discover(client: &Client, mcp_url: &str) -> Result<OAuthMetadata> {
         "{}/.well-known/oauth-authorization-server",
         auth_server.trim_end_matches('/')
     );
-    let meta_resp = client
-        .get(&meta_url)
-        .send()
-        .await
-        .map_err(|e| Error::Provider(format!("oauth server metadata: {e}")))?;
-    let meta: Value = meta_resp
-        .json()
-        .await
-        .map_err(|e| Error::Provider(format!("oauth server metadata json: {e}")))?;
+    let meta: Value = tokio::time::timeout(std::time::Duration::from_secs(15), async {
+        let resp = client
+            .get(&meta_url)
+            .send()
+            .await
+            .map_err(|e| Error::Provider(format!("oauth server metadata: {e}")))?;
+        resp.json::<Value>()
+            .await
+            .map_err(|e| Error::Provider(format!("oauth server metadata json: {e}")))
+    })
+    .await
+    .map_err(|_| Error::Provider(format!("oauth server metadata: timed out fetching {meta_url} (15s)")))??;
 
     let authorization_endpoint = meta
         .get("authorization_endpoint")

--- a/crates/core/src/repl.rs
+++ b/crates/core/src/repl.rs
@@ -1112,7 +1112,13 @@ fn parse_mcp_subcommand(args: &str) -> SlashCommand {
                                     "--header expects \"Key: Value\" (got '{spec}')"
                                 ));
                             };
-                            headers.push((k.trim().to_string(), v.trim().to_string()));
+                            let key = k.trim();
+                            if key.is_empty() {
+                                return SlashCommand::Unknown(format!(
+                                    "--header has an empty key (got '{spec}')"
+                                ));
+                            }
+                            headers.push((key.to_string(), v.trim().to_string()));
                             j += 2;
                         }
                         other => {
@@ -9183,6 +9189,16 @@ mod tests {
         // Malformed --header (no colon) → Unknown.
         assert!(matches!(
             parse_slash("/mcp add fd https://x.test/api --header nocolon"),
+            Some(SlashCommand::Unknown(_))
+        ));
+        // Empty header key → Unknown.
+        assert!(matches!(
+            parse_slash("/mcp add fd https://x.test/api --header \": value\""),
+            Some(SlashCommand::Unknown(_))
+        ));
+        // --header with no following value → Unknown.
+        assert!(matches!(
+            parse_slash("/mcp add fd https://x.test/api --header"),
             Some(SlashCommand::Unknown(_))
         ));
         assert_eq!(

--- a/crates/core/src/repl.rs
+++ b/crates/core/src/repl.rs
@@ -297,6 +297,10 @@ pub enum SlashCommand {
         name: String,
         url: String,
         user: bool,
+        /// Optional HTTP headers from repeatable `--header "K: V"` flags.
+        /// Values may contain `${VAR}` — resolved from the environment at
+        /// connection time so secrets stay out of mcp.json.
+        headers: Vec<(String, String)>,
     },
     /// `/mcp add <name> <command> [args...]` — stdio transport, sibling
     /// of `McpAdd` (HTTP). Routed by `parse_mcp_subcommand` based on
@@ -1054,45 +1058,81 @@ fn parse_mcp_subcommand(args: &str) -> SlashCommand {
     let (sub, rest) = args.split_once(char::is_whitespace).unwrap_or((args, ""));
     match sub {
         "add" => {
-            let mut parts: Vec<&str> = rest.split_whitespace().collect();
+            // Quote-aware tokenize so `--header "X-API-KEY: abc"` keeps
+            // its value (which contains a space after the colon) intact.
+            let tokens = tokenize_quoted(rest);
             let mut user = false;
-            if parts.first().copied() == Some("--user") {
-                user = true;
-                parts.remove(0);
-            } else if parts.first().copied() == Some("--project") {
-                parts.remove(0);
+            let mut idx = 0;
+            // Leading scope flags. (`--header` is parsed *after* the URL,
+            // curl-style, so a stdio command's own flags pass through.)
+            while idx < tokens.len() {
+                match tokens[idx].as_str() {
+                    "--user" => {
+                        user = true;
+                        idx += 1;
+                    }
+                    "--project" => {
+                        idx += 1;
+                    }
+                    _ => break,
+                }
             }
+            let positionals = &tokens[idx..];
             // Need at least <name> <url-or-command>.
-            if parts.len() < 2 {
+            if positionals.len() < 2 {
                 return SlashCommand::Unknown(
-                    "usage: /mcp add [--user] <name> <url>\n   or: /mcp add [--user] <name> <command> [args...]"
+                    "usage: /mcp add [--user] <name> <url> [--header \"Key: Value\"]\n   or: /mcp add [--user] <name> <command> [args...]"
                         .into(),
                 );
             }
-            let name = parts[0].to_string();
-            let target = parts[1];
+            let name = positionals[0].clone();
+            let target = positionals[1].clone();
+            let trailing = &positionals[2..];
             // Route by shape: a URL means HTTP transport; anything
             // else is treated as a stdio command. We don't probe the
             // command — first spawn happens in the dispatch arm and
             // surfaces any failure (missing binary, missing env, etc.)
             // via the existing error path.
             if target.starts_with("http://") || target.starts_with("https://") {
-                if parts.len() != 2 {
-                    return SlashCommand::Unknown(
-                        "usage: /mcp add [--user] <name> <url> (HTTP transport takes no extra args)"
-                            .into(),
-                    );
+                // Trailing tokens for HTTP are `--header`/`-H "Key: Value"`
+                // pairs (repeatable). Values may contain `${VAR}`, resolved
+                // from the environment at connect time.
+                let mut headers: Vec<(String, String)> = Vec::new();
+                let mut j = 0;
+                while j < trailing.len() {
+                    match trailing[j].as_str() {
+                        "--header" | "-H" => {
+                            let Some(spec) = trailing.get(j + 1) else {
+                                return SlashCommand::Unknown(
+                                    "--header expects a following \"Key: Value\"".into(),
+                                );
+                            };
+                            let Some((k, v)) = spec.split_once(':') else {
+                                return SlashCommand::Unknown(format!(
+                                    "--header expects \"Key: Value\" (got '{spec}')"
+                                ));
+                            };
+                            headers.push((k.trim().to_string(), v.trim().to_string()));
+                            j += 2;
+                        }
+                        other => {
+                            return SlashCommand::Unknown(format!(
+                                "unexpected arg '{other}' after <url> — HTTP transport accepts only --header \"Key: Value\""
+                            ));
+                        }
+                    }
                 }
                 SlashCommand::McpAdd {
                     name,
-                    url: target.to_string(),
+                    url: target,
                     user,
+                    headers,
                 }
             } else {
                 SlashCommand::McpAddStdio {
                     name,
-                    command: target.to_string(),
-                    args: parts[2..].iter().map(|s| (*s).to_string()).collect(),
+                    command: target,
+                    args: trailing.iter().map(|s| s.to_string()).collect(),
                     user,
                 }
             }
@@ -3095,10 +3135,13 @@ pub fn render_help() -> &'static str {
      /memory           List memory entries\n  \
      /memory read NAME Show a memory entry by name\n  \
      /mcp              List active MCP servers and their tools\n  \
-     /mcp add [--user] <name> <url>\n  \
+     /mcp add [--user] <name> <url> [--header \"K: V\"]\n  \
                        Register a remote (HTTP) MCP server. Writes to\n  \
                        .thclaws/mcp.json (or ~/.config/thclaws/mcp.json\n  \
                        with --user), then connects and registers tools.\n  \
+                       --header (repeatable) sets auth headers, e.g.\n  \
+                       --header \"X-API-KEY: ${MY_KEY}\" (${VAR} resolves\n  \
+                       from the environment at connect time).\n  \
      /mcp add [--user] <name> <command> [args...]\n  \
                        Register a local (stdio) MCP server. Same persist\n  \
                        + spawn flow; first arg is the binary, remaining\n  \
@@ -6238,7 +6281,12 @@ pub async fn run_repl(mut config: AppConfig) -> Result<()> {
                         }
                     }
                 }
-                SlashCommand::McpAdd { name, url, user } => {
+                SlashCommand::McpAdd {
+                    name,
+                    url,
+                    user,
+                    headers,
+                } => {
                     let scope = if user { "user" } else { "project" };
                     // /mcp add is hand-add — untrusted by default. To
                     // enable widget rendering on a self-added server,
@@ -6251,7 +6299,11 @@ pub async fn run_repl(mut config: AppConfig) -> Result<()> {
                         args: Vec::new(),
                         env: Default::default(),
                         url: url.clone(),
-                        headers: Default::default(),
+                        // Stored verbatim — `${VAR}` is resolved from the
+                        // environment at connect time (mcp::connect_http),
+                        // so a `${API_KEY}` placeholder keeps the literal
+                        // secret out of mcp.json.
+                        headers: headers.iter().cloned().collect(),
                         trusted: false,
                     };
                     // 1. Persist to disk.
@@ -6262,8 +6314,12 @@ pub async fn run_repl(mut config: AppConfig) -> Result<()> {
                             continue;
                         }
                     };
-                    // 2. Connect and list tools.
-                    match crate::mcp::McpClient::spawn(cfg.clone()).await {
+                    // 2. Connect and list tools. Non-interactive: if the
+                    //    server requires OAuth we don't block the REPL on a
+                    //    browser callback — the error tells the user to run
+                    //    `/mcp reauth <name>` (issue #114). CLI has no GUI
+                    //    approver (stdio falls back to stdin).
+                    match crate::mcp::McpClient::spawn_noninteractive(cfg.clone(), None).await {
                         Ok(client) => match client.list_tools().await {
                             Ok(tools) => {
                                 let names: Vec<String> =
@@ -9068,6 +9124,7 @@ mod tests {
                 name: "weather".into(),
                 url: "https://example.com/mcp".into(),
                 user: false,
+                headers: vec![],
             })
         );
         assert_eq!(
@@ -9076,8 +9133,58 @@ mod tests {
                 name: "weather".into(),
                 url: "https://example.com/mcp".into(),
                 user: true,
+                headers: vec![],
             })
         );
+        // --header "K: V" (quoted, space after colon) → one header pair.
+        assert_eq!(
+            parse_slash(
+                "/mcp add fd https://mcp.financialdatasets.ai/api --header \"X-API-KEY: abc123\""
+            ),
+            Some(SlashCommand::McpAdd {
+                name: "fd".into(),
+                url: "https://mcp.financialdatasets.ai/api".into(),
+                user: false,
+                headers: vec![("X-API-KEY".into(), "abc123".into())],
+            })
+        );
+        // Repeatable; -H alias; flags before positionals; ${VAR} preserved
+        // verbatim (resolved later at connect time).
+        assert_eq!(
+            parse_slash(
+                "/mcp add --user fd https://x.test/api -H \"X-API-KEY: ${FD_KEY}\" --header \"X-Trace: on\""
+            ),
+            Some(SlashCommand::McpAdd {
+                name: "fd".into(),
+                url: "https://x.test/api".into(),
+                user: true,
+                headers: vec![
+                    ("X-API-KEY".into(), "${FD_KEY}".into()),
+                    ("X-Trace".into(), "on".into()),
+                ],
+            })
+        );
+        // After a stdio (non-URL) command, --header is just a passed-through
+        // arg, not one of our flags.
+        assert_eq!(
+            parse_slash("/mcp add foo some-cmd --header bar"),
+            Some(SlashCommand::McpAddStdio {
+                name: "foo".into(),
+                command: "some-cmd".into(),
+                args: vec!["--header".into(), "bar".into()],
+                user: false,
+            })
+        );
+        // After a URL, only --header is accepted — a bare positional is rejected.
+        assert!(matches!(
+            parse_slash("/mcp add fd https://x.test/api bogus"),
+            Some(SlashCommand::Unknown(_))
+        ));
+        // Malformed --header (no colon) → Unknown.
+        assert!(matches!(
+            parse_slash("/mcp add fd https://x.test/api --header nocolon"),
+            Some(SlashCommand::Unknown(_))
+        ));
         assert_eq!(
             parse_slash("/mcp remove weather"),
             Some(SlashCommand::McpRemove {

--- a/crates/core/src/shell_dispatch.rs
+++ b/crates/core/src/shell_dispatch.rs
@@ -2490,7 +2490,12 @@ pub async fn dispatch(
                 emit(events_tx, out);
             }
         }
-        SlashCommand::McpAdd { name, url, user } => {
+        SlashCommand::McpAdd {
+            name,
+            url,
+            user,
+            headers,
+        } => {
             // Hand-add is untrusted by default; enabling widget UI
             // requires the user to edit mcp.json and set
             // `"trusted": true` explicitly.
@@ -2501,7 +2506,9 @@ pub async fn dispatch(
                 args: Vec::new(),
                 env: Default::default(),
                 url,
-                headers: Default::default(),
+                // Stored verbatim; `${VAR}` resolved from env at connect
+                // time (mcp::connect_http) so secrets stay out of mcp.json.
+                headers: headers.into_iter().collect(),
                 trusted: false,
             };
             persist_and_register_mcp(state, events_tx, cfg, user).await;
@@ -3864,7 +3871,11 @@ async fn persist_and_register_mcp(
             return;
         }
     };
-    match crate::mcp::McpClient::spawn_with_approver(cfg.clone(), Some(state.approver.clone()))
+    // Non-interactive: an HTTP server needing OAuth returns a "run
+    // /mcp reauth" error instead of blocking the worker thread for up
+    // to 5 min on a browser callback (issue #114). stdio keeps the GUI
+    // approver for the command-allowlist gate.
+    match crate::mcp::McpClient::spawn_noninteractive(cfg.clone(), Some(state.approver.clone()))
         .await
     {
         Ok(client) => match client.list_tools().await {


### PR DESCRIPTION
Closes #114. Adding a remote MCP server that requires OAuth (e.g. financial-datasets' root URL `https://mcp.financialdatasets.ai/`) froze `/mcp add` for up to **5 minutes**.

## Root cause (static trace — no live repro needed)

`/mcp add <name> <url>` runs the full connect **inline** on the command/worker thread (`repl.rs` McpAdd handler, `shell_dispatch.rs` `persist_and_register_mcp`). `connect_http` → `resolve_token_upfront` sends a `ping`, the OAuth-gated root URL returns **401**, and the code then blocks on `oauth::wait_for_callback` (a **5-minute** browser-consent timeout). The whole CLI REPL / GUI worker is frozen meanwhile. Separately, there was no way to use the simpler API-key path: `/mcp add` rejected any header arg, so `X-API-KEY` could only be set by hand-editing `mcp.json`.

(RFC 9728 discovery is correct — `oauth.rs` already probes `/.well-known/oauth-protected-resource` → `authorization_servers` → RFC 8414. Not the bug.)

## Four fixes

1. **Headers in `/mcp add`** — `/mcp add <name> <url> --header "Key: Value"` (repeatable, `-H` alias). Routes through the existing per-request header path. Lets users hit financial-datasets' `/api` endpoint with `X-API-KEY` and skip OAuth entirely.
2. **Probe + discovery timeouts** — the upfront auth-probe client gets a 15s request / 10s connect timeout; `oauth::discover` wraps both well-known GETs in a 15s `tokio::time::timeout`. A stalled/black-holed server can no longer hang `/mcp add` (or a startup spawn) forever.
3. **Non-blocking add** — `/mcp add` (CLI + GUI) spawns non-interactively: an HTTP server needing OAuth returns `run /mcp reauth <name>` instead of blocking on a browser callback. stdio keeps its approver (command-allowlist gate intact). Startup / `/mcp reauth` stay interactive (browser flow runs backgrounded, unchanged).
4. **`${VAR}` interpolation** in header values, resolved from the environment at connect time — `--header "X-API-KEY: ${FD_KEY}"` keeps the literal secret out of `mcp.json`. Unset var → literal `${VAR}` left in place (visible misconfig, not a silent empty header). Bare `$VAR` is not expanded.

## Tested without the paid API

Everything is validated with wiremock + unit tests — **no financial-datasets key required**:

- `probe_sends_headers_and_defers_oauth_when_noninteractive` — wiremock requiring `X-API-KEY`: with the header → `Proceed(None)` (no OAuth); a 401 server with non-interactive → `OAuthRequired` (defer, don't block).
- `probe_timeout_does_not_hang` — wiremock with a 10s delay + a short-timeout client → returns in <3s instead of hanging.
- `interpolate_with_resolves_braced_vars_only` — closure-injected lookup (no env mutation, so no race with the scheduler tests' `posix_spawn`): braces resolve, multiple vars, unset→literal, bare `$` untouched, unterminated brace safe.
- `parse_slash_mcp_subcommands` — extended: `--header`/`-H`, quoted `"K: V"`, `${VAR}` preserved verbatim, malformed (no colon) → Unknown, bare trailing positional after URL → Unknown, stdio pass-through.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo build --features gui --bin thclaws` / `--bin thclaws` (no gui) / `--bin thclaws-cli`
- [x] `cargo clippy --features gui` — no new warnings in changed code
- [x] `cargo test --features gui --lib -- --test-threads=1` — **1463 passed, 0 failed**
- [ ] Live financial-datasets check (maintainer, if a key is available): `/mcp add fd https://mcp.financialdatasets.ai/api --header "X-API-KEY: ${FD_KEY}"`

## Works today (pre-merge) for #114 reporter

The config-level header path already exists on v0.16.x — only the `/mcp add` command couldn't set it. Hand-edit `.thclaws/mcp.json`:
```json
{ "mcpServers": { "financial-datasets": {
    "transport": "http",
    "url": "https://mcp.financialdatasets.ai/api",
    "headers": { "X-API-KEY": "your-key" }
}}}
```
After this PR, `/mcp add financial-datasets https://mcp.financialdatasets.ai/api --header "X-API-KEY: ${FD_KEY}"` does the same.