### PR TITLE
fix(line): throttle reconnect after a clean websocket close

### DIFF
--- a/crates/core/src/line/client.rs
+++ b/crates/core/src/line/client.rs
@@ -271,6 +271,14 @@ impl LineClient {
                 Ok(()) => {
                     eprintln!("[line] ws closed cleanly; reconnecting");
                     backoff = Duration::from_secs(1);
+                    // Pause briefly before reconnecting. A relay that
+                    // repeatedly closes the connection cleanly (e.g. on
+                    // restart, idle timeout, or an immediate close on
+                    // connect) would otherwise spin this loop in an
+                    // unthrottled connect/close reconnect storm.
+                    if self.sleep_with_cancel(Duration::from_secs(1)).await {
+                        return Err(LineClientError::Cancelled);
+                    }
                 }
                 Err(LineClientError::Cancelled) => return Err(LineClientError::Cancelled),
                 Err(e) => {


### PR DESCRIPTION
## Problem

In `crates/core/src/line/client.rs`, `LineClient::run` handles a clean websocket close (the `Ok(())` arm) by resetting `backoff` and **immediately** looping back into `connect_and_pump` with no delay. The error arm, by contrast, sleeps with exponential backoff.

`connect_and_pump` returns `Ok(())` on several non-error conditions — a `Closed` control envelope, a websocket `Close` frame, and the stream ending (`None`). So a relay that closes the connection cleanly on every connect (a restart, an idle timeout, or an immediate close on connect) makes the loop spin: connect → clean close → reconnect, completely unthrottled — a reconnect storm against the relay.

## Fix

Add a cancel-aware 1-second pause on the clean-close path before reconnecting, mirroring the error path's `sleep_with_cancel`:

```rust
Ok(()) => {
    eprintln!("[line] ws closed cleanly; reconnecting");
    backoff = Duration::from_secs(1);
    if self.sleep_with_cancel(Duration::from_secs(1)).await {
        return Err(LineClientError::Cancelled);
    }
}
```

A fixed 1s (rather than escalating) keeps the fix minimal: the error path already escalates 1s→60s for a genuinely failing relay, and any non-zero floor removes the storm.

## Behavior / compatibility

- After a clean close the client now waits 1s before reconnecting (was: immediate). For the single-client-per-user LINE relay this is imperceptible, and outbound replies/pushes go over independent HTTP, so they are unaffected.
- **Shutdown is not affected**: the wait is cancel-aware — when the `CancelToken` fires it returns `Cancelled` immediately, preserving the documented "exits early with Cancelled when the CancelToken is fired (and only then)" contract.

## Testing

Verified by inspection: every `Ok(())` return path from `connect_and_pump` now flows through the new throttle, and `sleep_with_cancel` returns `true` only on cancellation. Runtime testing requires a live LINE websocket relay, and there is currently no transport seam (`connect_and_pump` dials `connect_async` directly) to unit-test the reconnect loop without a refactor. `cargo fmt`, `cargo check -p thclaws-core --lib`, and `cargo clippy` are clean for this file (no new warnings).