### PR TITLE
fix(edit): reject an empty old_string

### DIFF
--- a/crates/core/src/tools/edit.rs
+++ b/crates/core/src/tools/edit.rs
@@ -52,6 +52,13 @@ impl Tool for EditTool {
             .and_then(Value::as_bool)
             .unwrap_or(false);
 
+        // An empty old_string matches between every character, so with
+        // replace_all it would inject new_string throughout the file and
+        // corrupt it. Reject it, matching docx_edit's find_replace guard.
+        if old.is_empty() {
+            return Err(Error::Tool("old_string must not be empty".into()));
+        }
+
         if old == new {
             return Err(Error::Tool(
                 "old_string and new_string are identical".into(),
@@ -164,5 +171,26 @@ mod tests {
         std::fs::write(&path, "x").unwrap();
         let err = edit(&path, "x", "x").await.unwrap_err();
         assert!(format!("{err}").contains("identical"));
+    }
+
+    #[tokio::test]
+    async fn empty_old_string_rejected() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("f.txt");
+        std::fs::write(&path, "abc").unwrap();
+        // Even with replace_all, an empty old_string must be rejected
+        // rather than injecting new_string between every character.
+        let err = EditTool
+            .call(json!({
+                "path": path.to_string_lossy(),
+                "old_string": "",
+                "new_string": "X",
+                "replace_all": true
+            }))
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("must not be empty"));
+        // file untouched
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "abc");
     }
 }


### PR DESCRIPTION
## Problem

`EditTool::call` (`crates/core/src/tools/edit.rs`) accepts an empty `old_string`. An empty string matches between every character, so:

- with `replace_all: true`, `contents.replace("", new_string)` injects `new_string` between **every** character of the file — silent corruption (e.g. a file `abc` with `old_string=""`, `new_string="X"` becomes `XaXbXcX`).
- with `replace_all: false`, a multi-character file has `count > 1`, so it errors with the misleading "appears N times" message.

## Fix

Reject an empty `old_string` up front, before any matching/replacement. This mirrors the existing guard in the sibling `docx_edit` tool — `find_replace` already does `if find.is_empty() { return Err(Error::Tool("find string must not be empty")) }` (`crates/core/src/tools/docx_edit.rs:170-172`, with a `empty_find_rejected` test). `edit` simply lacked the equivalent.

```rust
if old.is_empty() {
    return Err(Error::Tool("old_string must not be empty".into()));
}
```

## Tests

Adds `empty_old_string_rejected`: with `replace_all: true` and an empty `old_string`, the call now returns an error and the file is left untouched. Before this change that input returned `Ok` and corrupted the file. All existing `edit` tests still pass (`cargo test -p thclaws-core --lib tools::edit`), and `cargo fmt`/`cargo check` are clean.