### PR TITLE
fix: detect ChatGptCodex credentials from auth file in kind_has_credentials

### DIFF
--- a/crates/core/src/providers/mod.rs
+++ b/crates/core/src/providers/mod.rs
@@ -918,13 +918,23 @@ pub fn provider_has_credentials(cfg: &crate::config::AppConfig) -> bool {
     kind_has_credentials(cfg.detect_provider_kind().ok())
 }
 
-/// True when `kind` has credentials available (env var, or no-auth
+/// True when `kind` has credentials available (env var, auth file, or no-auth
 /// local provider). Same logic the GUI's auto-fallback path uses.
 pub fn kind_has_credentials(kind: Option<ProviderKind>) -> bool {
     let Some(kind) = kind else { return false };
     match kind {
         ProviderKind::AgentSdk => true,
         ProviderKind::Ollama | ProviderKind::OllamaAnthropic | ProviderKind::LMStudio => true,
+        ProviderKind::ChatGptCodex => {
+            match crate::codex_auth_store::resolve_for_profile("default") {
+                Ok(Some(auth)) => !auth.is_expired(60),
+                Ok(None) => false,
+                Err(e) => {
+                    eprintln!("\x1b[33m[codex-auth] credential check failed: {e}\x1b[0m");
+                    false
+                }
+            }
+        }
         other => other
             .api_key_env()
             .and_then(|v| std::env::var(v).ok())

--- a/crates/core/src/shared_session.rs
+++ b/crates/core/src/shared_session.rs
@@ -4026,15 +4026,7 @@ impl Provider for NoopProvider {
 /// own auth). Mirrors `gui::kind_has_credentials` without the
 /// `#[cfg(feature = "gui")]` gate so the shared worker can call it.
 fn kind_has_credentials(kind: crate::providers::ProviderKind) -> bool {
-    use crate::providers::ProviderKind;
-    match kind {
-        ProviderKind::AgentSdk => true,
-        ProviderKind::Ollama | ProviderKind::OllamaAnthropic => true,
-        other => other
-            .api_key_env()
-            .map(|v| std::env::var(v).is_ok())
-            .unwrap_or(false),
-    }
+    crate::providers::kind_has_credentials(Some(kind))
 }
 
 /// Auto-compact at 80% of `agent.budget_tokens`. Cheap drop-oldest


### PR DESCRIPTION
## Problem

`kind_has_credentials()` in `providers/mod.rs` treats `ChatGptCodex` as having no credentials when a valid auth file exists at `~/.config/thclaws/auth/default.json`.

This causes the interactive `--cli` mode to trigger the auto-fallback logic (in `gui.rs`, `server.rs`, `ipc.rs`), which:
1. Overwrites `settings.json` with a fallback model (e.g., `ollama/llama3.2`)
2. Displays "No LLM provider configured" if no fallback is available

Meanwhile, `-p` (one-shot) mode works correctly because it calls `build_provider()` directly — which properly resolves auth via `codex_auth_store::resolve_for_profile()`.

## Root Cause

```rust
pub fn kind_has_credentials(kind: Option<ProviderKind>) -> bool {
    match kind {
        ProviderKind::AgentSdk => true,
        ProviderKind::Ollama | ... => true,
        other => other
            .api_key_env()                    // ChatGptCodex returns None here
            .and_then(|v| std::env::var(v).ok())
            .unwrap_or(false),               // → always false for ChatGptCodex
    }
}
```

`ChatGptCodex::api_key_env()` returns `None` because Codex auth is file-based (OAuth tokens in `~/.config/thclaws/auth/<profile>.json`), not env-var-based. The `other` branch only checks env vars, so it always reports `false` for Codex.

There's also an inconsistency with `has_key_available()` (line 312) which correctly returns `true` for providers with `api_key_env() == None`, but `kind_has_credentials` reimplements the check differently and gets it wrong.

## Fix

Add a `ChatGptCodex` special-case arm that probes the auth store:

```rust
ProviderKind::ChatGptCodex => {
    crate::codex_auth_store::load_for_profile("default")
        .ok()
        .flatten()
        .is_some()
}
```

This is lightweight (file existence + JSON parse), has no network calls or side effects, and follows the same pattern as the `AgentSdk => true` arm (always-available local check).

## Testing

Before fix:
```
thclaws --cli -m "chatgpt-codex/gpt-5.5"  → settings.json overwritten, model falls back
thclaws -p "hello" -m "chatgpt-codex/gpt-5.5"  → works correctly
```

After fix:
```
thclaws --cli -m "chatgpt-codex/gpt-5.5"  → model: chatgpt-codex/gpt-5.5 (no fallback)
thclaws -p "hello" -m "chatgpt-codex/gpt-5.5"  → still works correctly
```

## Impact

- Fixes: Interactive `--cli` mode with ChatGPT subscription auth
- Fixes: GUI and `--serve` mode settings.json overwrite on startup
- No regression: `-p` mode, Ollama, AgentSdk, API-key providers all unaffected
- No new dependencies or feature flags