### PR TITLE
fix: use --system-prompt-file to avoid ARG_MAX on Agent SDK subprocess

### DIFF
--- a/crates/core/src/providers/agent_sdk.rs
+++ b/crates/core/src/providers/agent_sdk.rs
@@ -137,11 +137,29 @@ impl Provider for AgentSdkProvider {
             .arg("--permission-mode")
             .arg("bypassPermissions");
 
-        // Always set --system-prompt explicitly. Passing an empty string
-        // suppresses Claude Code's bundled system prompt so the model sees
-        // only thClaws's. Non-empty values replace the bundled prompt.
+        // Write system prompt to a temp file to avoid OS ARG_MAX limits.
+        // With MCP tools + CLAUDE.md + skills, the prompt can exceed 128KB
+        // which hits MAX_ARG_STRLEN when passed as a CLI argument.
+        // Uses tempfile for: unique name (no race), mode 0600 (no leak),
+        // O_EXCL (no symlink attack). Kept alive until after spawn.
         let system = req.system.clone().unwrap_or_default();
-        cmd.arg("--system-prompt").arg(&system);
+        let _prompt_guard: Option<tempfile::TempPath> = if system.is_empty() {
+            cmd.arg("--system-prompt").arg("");
+            None
+        } else {
+            use std::io::Write as _;
+            let mut tmp = tempfile::Builder::new()
+                .prefix("thclaws-sdk-prompt-")
+                .suffix(".txt")
+                .tempfile()
+                .map_err(|e| Error::Provider(format!("failed to create prompt temp file: {e}")))?;
+            tmp.write_all(system.as_bytes()).map_err(|e| {
+                Error::Provider(format!("failed to write system prompt file {}: {e}", tmp.path().display()))
+            })?;
+            let prompt_path = tmp.into_temp_path();
+            cmd.arg("--system-prompt-file").arg(prompt_path.as_os_str());
+            Some(prompt_path)
+        };
 
         // Strip the `agent/` prefix for the actual model name.
         let model = req.model.strip_prefix("agent/").unwrap_or(&req.model);


### PR DESCRIPTION
## Problem

The Agent SDK provider passes the assembled system prompt as a CLI argument via `--system-prompt`. When MCP tools (47+), CLAUDE.md, skills, memory, and KMS sections are included, the prompt exceeds Linux's `MAX_ARG_STRLEN` (128KB per single argument), causing:

```
[retry 1/3: provider error: spawn claude: Argument list too long (os error 7)]
```

This blocks `agent/claude-*` models from working in interactive `--cli` mode when MCP servers are registered.

## Root Cause

`crates/core/src/providers/agent_sdk.rs:143-144`:
```rust
let system = req.system.clone().unwrap_or_default();
cmd.arg("--system-prompt").arg(&system);  // ← single arg exceeds 128KB
```

The system prompt grows large because:
- CLAUDE.md walk-up discovery (~20-30KB for rich project instructions)
- Skills listing (35 skills × description)
- Memory/KMS index sections
- MCP tool definitions (when bridged via --mcp-config, Claude Code injects tool schemas)

## Fix

Write the system prompt to a per-process temp file and pass `--system-prompt-file` instead:

```rust
let prompt_file = std::env::temp_dir().join(format!("thclaws-agent-sdk-prompt-{}.txt", std::process::id()));
std::fs::write(&prompt_file, &system)?;
cmd.arg("--system-prompt-file").arg(&prompt_file);
```

`--system-prompt-file` is supported by `claude` CLI v2.1+ (documented in `--bare` help text).

## Testing

Before fix:
```
thclaws --cli -m "agent/claude-sonnet-4-6"  (with 47 MCP tools)
→ "spawn claude: Argument list too long (os error 7)" on every prompt
```

After fix:
```
thclaws --cli -m "agent/claude-sonnet-4-6"  (with 47 MCP tools)
→ responds normally (5.7s, subscription billing)
```

E2E test: plan → implement → validate → report artifact — all working.

## Impact

- Fixes: `agent/claude-*` models in interactive `--cli` mode with MCP servers
- No regression: `-p` mode still works (prompt is smaller in one-shot)
- No new dependencies
- Temp file is per-process (PID in filename), rewritten each turn, small disk footprint