### PR TITLE
feat: tool progress visibility — rich labels, spinner, heartbeat, streaming

### DIFF
--- a/crates/core/src/event_render.rs
+++ b/crates/core/src/event_render.rs
@@ -57,7 +57,7 @@ pub fn render_chat_dispatches(ev: &ViewEvent) -> Vec<String> {
             "type": "chat_tool_call",
             "name": strip_ansi(label),
             "tool_name": name,
-            "input": input,
+            "input": crate::tool_display::redact_json_value(input),
         })
         .to_string()],
         ViewEvent::ToolCallResult {
@@ -319,6 +319,7 @@ pub fn strip_ansi(s: &str) -> String {
 #[derive(Default)]
 pub struct TerminalRenderState {
     last_tool_label: Option<String>,
+    last_tool_started_at: Option<std::time::Instant>,
     last_tool_count: u32,
     merging: bool,
     pending_newline_after_tool: bool,
@@ -353,9 +354,11 @@ pub fn render_terminal_ansi(state: &mut TerminalRenderState, ev: &ViewEvent) -> 
             {
                 state.pending_newline_after_tool = false;
                 state.merging = true;
+                state.last_tool_started_at = Some(std::time::Instant::now());
                 return None;
             }
             state.last_tool_label = Some(label.clone());
+            state.last_tool_started_at = Some(std::time::Instant::now());
             state.last_tool_count = 0;
             state.merging = false;
             state.pending_newline_after_tool = false;
@@ -363,10 +366,16 @@ pub fn render_terminal_ansi(state: &mut TerminalRenderState, ev: &ViewEvent) -> 
         }
         ViewEvent::ToolCallResult { output, .. } => {
             state.last_was_thinking = false;
+            let duration_suffix = state
+                .last_tool_started_at
+                .take()
+                .map(|t| format!(" {}", crate::tool_display::format_duration(t.elapsed())))
+                .unwrap_or_default();
             // M6.38.9: surface upstream source (e.g. "via Tavily")
             // next to the ✓ when the tool emits a `Source: <engine>`
             // line. Independent of whether the model surfaces it.
             let src_suffix = crate::tools::extract_tool_source(output)
+                .map(|s| crate::tool_display::sanitize_label_field(s))
                 .map(|s| format!(" \x1b[2m(via {s})\x1b[0m"))
                 .unwrap_or_default();
             if state.merging {
@@ -376,12 +385,12 @@ pub fn render_terminal_ansi(state: &mut TerminalRenderState, ev: &ViewEvent) -> 
                 let label = state.last_tool_label.clone().unwrap_or_default();
                 let count = state.last_tool_count;
                 return Some(format!(
-                    "\r\x1b[2K\x1b[2m[tool: {label}]\x1b[0m \x1b[32m✓\x1b[0m{src_suffix} \x1b[2m×{count}\x1b[0m"
+                    "\r\x1b[2K\x1b[2m[tool: {label}]\x1b[0m \x1b[32m✓{duration_suffix}\x1b[0m{src_suffix} \x1b[2m×{count}\x1b[0m"
                 ));
             }
             state.last_tool_count = 1;
             state.pending_newline_after_tool = true;
-            return Some(format!(" \x1b[32m✓\x1b[0m{src_suffix}"));
+            return Some(format!(" \x1b[32m✓{duration_suffix}\x1b[0m{src_suffix}"));
         }
         _ => {}
     }

--- a/crates/core/src/gui.rs
+++ b/crates/core/src/gui.rs
@@ -1234,7 +1234,8 @@ mod tool_coalesce_tests {
         assert!(out.contains("[tool: Ls]"));
         assert!(out.starts_with("\r\n"));
         let res = render_terminal_ansi(&mut s, &ok()).unwrap();
-        assert_eq!(res, " \x1b[32m✓\x1b[0m");
+        assert!(res.starts_with(" \x1b[32m✓"));
+        assert!(res.ends_with("\x1b[0m"));
     }
 
     #[test]
@@ -1280,9 +1281,9 @@ mod tool_coalesce_tests {
     #[test]
     fn chat_dispatch_carries_tool_name_and_input_for_todowrite() {
         // Frontend keys on `tool_name === "TodoWrite"` to render the
-        // checklist card. The IPC envelope must carry both the
-        // unmangled tool name and the raw input so the renderer has
-        // everything it needs without a follow-up round-trip.
+        // checklist card. The IPC envelope must carry the unmangled
+        // tool name and a redacted copy of the input so the renderer has
+        // everything it needs without leaking secrets.
         let ev = ViewEvent::ToolCallStart {
             name: "TodoWrite".to_string(),
             label: "TodoWrite".to_string(),
@@ -1290,7 +1291,8 @@ mod tool_coalesce_tests {
                 "todos": [
                     { "id": "1", "content": "Investigate bug", "status": "in_progress" },
                     { "id": "2", "content": "Write fix", "status": "pending" },
-                ]
+                ],
+                "note": "Authorization: Bearer sk-123",
             }),
         };
         let dispatches = render_chat_dispatches(&ev);
@@ -1306,5 +1308,9 @@ mod tool_coalesce_tests {
         assert!(todos.is_array(), "todos array missing in input: {envelope}");
         assert_eq!(todos[0]["content"], "Investigate bug");
         assert_eq!(todos[0]["status"], "in_progress");
+        assert_eq!(
+            envelope["input"]["note"],
+            "Authorization: Bearer <redacted>"
+        );
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -93,6 +93,7 @@ pub mod team;
 pub mod telegram;
 pub mod theme;
 pub mod tokens;
+pub mod tool_display;
 pub mod tools;
 pub mod types;
 pub mod uploads;

--- a/crates/core/src/providers/agent_sdk.rs
+++ b/crates/core/src/providers/agent_sdk.rs
@@ -337,12 +337,47 @@ impl Provider for AgentSdkProvider {
             let mut seen_start = false;
             let mut first_text_yielded = false;
             let mut raw = raw_dump;
-
+            let mut active_tools: std::collections::HashMap<String, crate::tool_display::ActiveToolDisplay> =
+                std::collections::HashMap::new();
+            let mut spinner_tick: u32 = 0;
+            let mut anon_counter: u32 = 0;
             loop {
                 line_buf.clear();
-                let n = reader.read_line(&mut line_buf).await
+
+                let heartbeat_delay = if !active_tools.is_empty() {
+                    crate::tool_display::SPINNER_INTERVAL
+                } else {
+                    std::time::Duration::from_secs(300)
+                };
+
+                let got_line: std::result::Result<Option<usize>, std::io::Error> =
+                    tokio::select! {
+                        biased;
+                        result = reader.read_line(&mut line_buf) => { result.map(Some) }
+                        _ = tokio::time::sleep(heartbeat_delay) => { Ok(None) }
+                    };
+                let got_line = got_line
                     .map_err(|e| Error::Provider(format!("read stdout: {e}")))?;
-                if n == 0 { break; } // EOF
+
+                if let Some(0) = got_line { break; } // EOF
+
+                if got_line.is_none() {
+                    spinner_tick += 1;
+                    if !active_tools.is_empty() {
+                        if let Some((id, _)) = active_tools.iter().min_by_key(|(_, td)| td.started_at) {
+                            let id = id.clone();
+                            if let Some(td) = active_tools.get_mut(&id) {
+                                yield ProviderEvent::TextDelta(
+                                    crate::tool_display::format_tool_spinner(&td.label, td.elapsed(), spinner_tick)
+                                );
+                                td.last_heartbeat_at = std::time::Instant::now();
+                            }
+                        }
+                    }
+                    continue;
+                }
+                spinner_tick = 0;
+
                 let trimmed = line_buf.trim();
                 if trimmed.is_empty() { continue; }
                 let Ok(v) = serde_json::from_str::<Value>(trimmed) else { continue };
@@ -384,12 +419,22 @@ impl Provider for AgentSdkProvider {
                                         }
                                     }
                                     "tool_use" => {
-                                        // Surface tool calls inline as a dim
-                                        // marker — actual execution happens
-                                        // server-side in Claude Code.
                                         let name = block.get("name").and_then(Value::as_str).unwrap_or("tool");
+                                        let id = block.get("id").and_then(Value::as_str).unwrap_or("").to_string();
+                                        let input = block.get("input").cloned().unwrap_or(Value::Null);
+                                        let label = crate::tool_display::tool_label(name, &input);
                                         yield ProviderEvent::TextDelta(
-                                            format!("\n\x1b[2m🔧 [{name}]\x1b[0m\n")
+                                            crate::tool_display::format_tool_spinner(&label, std::time::Duration::ZERO, 0)
+                                        );
+                                        let tracking_id = if id.is_empty() {
+                                            anon_counter += 1;
+                                            format!("__anon_{anon_counter}")
+                                        } else {
+                                            id
+                                        };
+                                        active_tools.insert(
+                                            tracking_id,
+                                            crate::tool_display::ActiveToolDisplay::new(label),
                                         );
                                     }
                                     _ => {}
@@ -397,17 +442,25 @@ impl Provider for AgentSdkProvider {
                             }
                         }
                     }
-                    // Tool result / user echo — claude echoes these on stdout
-                    // as it runs tools server-side. We ignore them; the model
-                    // already has them server-side.
-                    "user" => {}
-                    // Inbound control_request from claude. With
-                    // --permission-mode bypassPermissions we don't get
-                    // permission prompts, but the SDK MCP bridge sends
-                    // `mcp_message` requests here whenever the model
-                    // calls a bridged tool — we dispatch via
-                    // crate::sdk_mcp and write a control_response back
-                    // through stdin.
+                    "user" => {
+                        if let Some(blocks) = v.pointer("/message/content").and_then(Value::as_array) {
+                            for block in blocks {
+                                let btype = block.get("type").and_then(Value::as_str).unwrap_or("");
+                                if btype == "tool_result" {
+                                    let tu_id = block.get("tool_use_id").and_then(Value::as_str).unwrap_or("");
+                                    let is_error = block.get("is_error").and_then(Value::as_bool).unwrap_or(false);
+                                    if let Some(td) = active_tools.remove(tu_id) {
+                                        yield ProviderEvent::TextDelta(
+                                            crate::tool_display::format_tool_done(&td.label, td.elapsed(), is_error)
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        if active_tools.is_empty() {
+                            spinner_tick = 0;
+                        }
+                    }
                     "control_request" => {
                         let req_id = v.get("request_id").and_then(Value::as_str).unwrap_or("").to_string();
                         let subtype = v.pointer("/request/subtype").and_then(Value::as_str).unwrap_or("");
@@ -432,9 +485,12 @@ impl Provider for AgentSdkProvider {
                                     },
                                 });
                                 if let Some(stdin) = stdin_handle.as_mut() {
-                                    let _ = stdin.write_all(envelope.to_string().as_bytes()).await;
-                                    let _ = stdin.write_all(b"\n").await;
-                                    let _ = stdin.flush().await;
+                                    if let Err(e) = stdin.write_all(envelope.to_string().as_bytes()).await {
+                                        eprintln!("[agent-sdk] mcp bridge: stdin write failed: {e}");
+                                    } else {
+                                        let _ = stdin.write_all(b"\n").await;
+                                        let _ = stdin.flush().await;
+                                    }
                                 }
                             }
                         }

--- a/crates/core/src/providers/openai.rs
+++ b/crates/core/src/providers/openai.rs
@@ -429,20 +429,60 @@ impl Provider for OpenAIProvider {
             let mut byte_stream = Box::pin(byte_stream);
             let mut state = ParseState::default();
             let mut raw = raw_dump;
+            let mut last_activity = std::time::Instant::now();
+            let mut idle_total = std::time::Duration::ZERO;
+            let mut spinner_tick: u32 = 0;
+            let mut is_animating = false;
 
             loop {
+                let wait = if is_animating {
+                    crate::tool_display::SPINNER_INTERVAL
+                } else {
+                    let since = last_activity.elapsed();
+                    let threshold = crate::tool_display::THINKING_HEARTBEAT_AFTER;
+                    let thinking_wait = if since >= threshold {
+                        crate::tool_display::SPINNER_INTERVAL
+                    } else {
+                        threshold - since
+                    };
+                    thinking_wait.min(chunk_timeout.saturating_sub(idle_total))
+                };
+
                 let maybe_chunk = tokio::time::timeout(
-                    chunk_timeout,
+                    wait,
                     byte_stream.next(),
                 )
-                .await
-                .map_err(|_| Error::Provider(format!(
-                    "stream idle for {}s — provider stopped sending; try again",
-                    chunk_timeout.as_secs()
-                )))?;
-                let Some(chunk) = maybe_chunk else { break };
-                let chunk = chunk.map_err(|e| Error::Provider(format!("stream: {e}")))?;
-                buffer.extend_from_slice(&chunk);
+                .await;
+
+                match maybe_chunk {
+                    Err(_) => {
+                        idle_total += wait;
+                        if idle_total >= chunk_timeout {
+                            Err(Error::Provider(format!(
+                                "stream idle for {}s — provider stopped sending; try again",
+                                chunk_timeout.as_secs()
+                            )))?;
+                        }
+                        is_animating = true;
+                        spinner_tick += 1;
+                        yield ProviderEvent::TextDelta(
+                            crate::tool_display::format_thinking_spinner(idle_total, spinner_tick)
+                        );
+                        continue;
+                    }
+                    Ok(maybe) => {
+                        let Some(chunk) = maybe else { break };
+                        let chunk = chunk.map_err(|e| Error::Provider(format!("stream: {e}")))?;
+                        buffer.extend_from_slice(&chunk);
+                        if is_animating {
+                            yield ProviderEvent::TextDelta(crate::tool_display::clear_thinking_line());
+                            is_animating = false;
+                            spinner_tick = 0;
+                        }
+                        last_activity = std::time::Instant::now();
+                        idle_total = std::time::Duration::ZERO;
+                    }
+                }
 
                 while let Some(boundary) = super::find_bytes(&buffer, b"\n\n") {
                     let event_bytes: Vec<u8> = buffer.drain(..boundary + 2).collect();

--- a/crates/core/src/providers/openai_responses.rs
+++ b/crates/core/src/providers/openai_responses.rs
@@ -302,20 +302,60 @@ impl Provider for OpenAIResponsesProvider {
             let mut byte_stream = Box::pin(byte_stream);
             let mut seen_start = false;
             let mut raw = raw_dump;
+            let mut last_activity = std::time::Instant::now();
+            let mut idle_total = std::time::Duration::ZERO;
+            let mut spinner_tick: u32 = 0;
+            let mut is_animating = false;
 
             loop {
+                let wait = if is_animating {
+                    crate::tool_display::SPINNER_INTERVAL
+                } else {
+                    let since = last_activity.elapsed();
+                    let threshold = crate::tool_display::THINKING_HEARTBEAT_AFTER;
+                    let thinking_wait = if since >= threshold {
+                        crate::tool_display::SPINNER_INTERVAL
+                    } else {
+                        threshold - since
+                    };
+                    thinking_wait.min(chunk_timeout.saturating_sub(idle_total))
+                };
+
                 let maybe_chunk = tokio::time::timeout(
-                    chunk_timeout,
+                    wait,
                     byte_stream.next(),
                 )
-                .await
-                .map_err(|_| Error::Provider(format!(
-                    "stream idle for {}s — provider stopped sending; try again",
-                    chunk_timeout.as_secs()
-                )))?;
-                let Some(chunk) = maybe_chunk else { break };
-                let chunk = chunk.map_err(|e| Error::Provider(format!("stream: {e}")))?;
-                buffer.extend_from_slice(&chunk);
+                .await;
+
+                match maybe_chunk {
+                    Err(_) => {
+                        idle_total += wait;
+                        if idle_total >= chunk_timeout {
+                            Err(Error::Provider(format!(
+                                "stream idle for {}s — provider stopped sending; try again",
+                                chunk_timeout.as_secs()
+                            )))?;
+                        }
+                        is_animating = true;
+                        spinner_tick += 1;
+                        yield ProviderEvent::TextDelta(
+                            crate::tool_display::format_thinking_spinner(idle_total, spinner_tick)
+                        );
+                        continue;
+                    }
+                    Ok(maybe) => {
+                        let Some(chunk) = maybe else { break };
+                        let chunk = chunk.map_err(|e| Error::Provider(format!("stream: {e}")))?;
+                        buffer.extend_from_slice(&chunk);
+                        if is_animating {
+                            yield ProviderEvent::TextDelta(crate::tool_display::clear_thinking_line());
+                            is_animating = false;
+                            spinner_tick = 0;
+                        }
+                        last_activity = std::time::Instant::now();
+                        idle_total = std::time::Duration::ZERO;
+                    }
+                }
 
                 while let Some(boundary) = super::find_bytes(&buffer, b"\n\n") {
                     let event_bytes: Vec<u8> = buffer.drain(..boundary + 2).collect();

--- a/crates/core/src/repl.rs
+++ b/crates/core/src/repl.rs
@@ -4599,10 +4599,16 @@ pub async fn run_repl(mut config: AppConfig) -> Result<()> {
                 let _ = mailbox.write_status(agent_name, "working", Some(&msg.id));
                 let mut last_heartbeat = std::time::Instant::now();
                 let turn_start = std::time::Instant::now();
+                let mut team_active_tools: std::collections::HashMap<
+                    String,
+                    crate::tool_display::ActiveToolDisplay,
+                > = std::collections::HashMap::new();
 
                 // Run the agent turn.
                 let mut stream = Box::pin(agent.run_turn(prompt));
                 loop {
+                    let heartbeat_delay =
+                        crate::tool_display::next_heartbeat_delay(&team_active_tools);
                     let ev = tokio::select! {
                         ev = stream.next() => ev,
                         _ = tokio::signal::ctrl_c() => {
@@ -4610,23 +4616,48 @@ pub async fn run_repl(mut config: AppConfig) -> Result<()> {
                             drop(stream);
                             break;
                         }
+                        _ = tokio::time::sleep(heartbeat_delay) => {
+                            if let Some(id) = crate::tool_display::oldest_due_heartbeat(&team_active_tools).map(|(k, _)| k.clone()) {
+                                if let Some(td) = team_active_tools.get_mut(&id) {
+                                    team_println!("\n{}", crate::tool_display::format_tool_heartbeat(&td.label, td.elapsed()));
+                                    td.last_heartbeat_at = std::time::Instant::now();
+                                }
+                            }
+                            continue;
+                        }
                     };
                     let Some(ev) = ev else { break };
                     match ev {
                         Ok(AgentEvent::Text(s)) => {
                             team_print!("{s}");
-                            // Throttled heartbeat — update every 30s on any output.
                             if last_heartbeat.elapsed().as_secs() >= 30 {
                                 let _ = mailbox.write_status(agent_name, "working", None);
                                 last_heartbeat = std::time::Instant::now();
                             }
                         }
-                        Ok(AgentEvent::ToolCallStart { name, .. }) => {
-                            team_print!("\n[tool: {name}]");
+                        Ok(AgentEvent::ToolCallStart {
+                            id, name, input, ..
+                        }) => {
+                            let label = crate::tool_display::tool_label(&name, &input);
+                            team_active_tools.insert(
+                                id,
+                                crate::tool_display::ActiveToolDisplay::new(label.clone()),
+                            );
+                            team_print!("\n[tool: {label}]");
                         }
-                        Ok(AgentEvent::ToolCallResult { output, .. }) => {
-                            team_println!("{}", if output.is_ok() { " ✓" } else { " ✗" });
-                            // Update heartbeat on tool completion.
+                        Ok(AgentEvent::ToolCallResult { id, output, .. }) => {
+                            let dur = team_active_tools.remove(&id).map(|t| t.elapsed());
+                            let dur_str = dur
+                                .map(|d| format!(" {}", crate::tool_display::format_duration(d)))
+                                .unwrap_or_default();
+                            team_println!(
+                                "{}",
+                                if output.is_ok() {
+                                    format!(" ✓{dur_str}")
+                                } else {
+                                    format!(" ✗{dur_str}")
+                                }
+                            );
                             let _ = mailbox.write_status(agent_name, "working", None);
                             last_heartbeat = std::time::Instant::now();
                         }
@@ -4839,7 +4870,10 @@ pub async fn run_repl(mut config: AppConfig) -> Result<()> {
                 let _ = std::io::stdout().flush();
                 let mut stream = Box::pin(agent.run_turn(team_prompt));
                 let mut last_was_thinking = false;
+                let mut active_tools: std::collections::HashMap<String, crate::tool_display::ActiveToolDisplay> =
+                    std::collections::HashMap::new();
                 loop {
+                    let heartbeat_delay = crate::tool_display::next_heartbeat_delay(&active_tools);
                     let ev = tokio::select! {
                         ev = stream.next() => ev,
                         _ = tokio::signal::ctrl_c() => {
@@ -4847,6 +4881,18 @@ pub async fn run_repl(mut config: AppConfig) -> Result<()> {
                             lead_log!("{COLOR_RESET}\n{COLOR_YELLOW}[cancelled]{COLOR_RESET}\n");
                             drop(stream);
                             break;
+                        }
+                        _ = tokio::time::sleep(heartbeat_delay) => {
+                            if let Some(id) = crate::tool_display::oldest_due_heartbeat(&active_tools).map(|(k, _)| k.clone()) {
+                                if let Some(td) = active_tools.get_mut(&id) {
+                                    let hb = crate::tool_display::format_tool_heartbeat(&td.label, td.elapsed());
+                                    println!("{COLOR_DIM}{hb}{COLOR_RESET}");
+                                    lead_log!("{COLOR_DIM}{hb}{COLOR_RESET}\n");
+                                    let _ = std::io::stdout().flush();
+                                    td.last_heartbeat_at = std::time::Instant::now();
+                                }
+                            }
+                            continue;
                         }
                     };
                     let Some(ev) = ev else { break };
@@ -4861,33 +4907,37 @@ pub async fn run_repl(mut config: AppConfig) -> Result<()> {
                             let _ = std::io::stdout().flush();
                         }
                         Ok(AgentEvent::Thinking(s)) => {
-                            // Dim-italic so reasoning is visibly distinct from
-                            // the final answer (DeepSeek v4/r1, glm4.7, etc.).
                             print!("\x1b[2;3m{s}\x1b[0m");
                             last_was_thinking = true;
                             let _ = std::io::stdout().flush();
                         }
-                        Ok(AgentEvent::ToolCallStart { name, .. }) => {
-                            // Tool-call line already starts with \n, so any
-                            // prior thinking is naturally separated; clear
-                            // the flag so we don't double-line.
+                        Ok(AgentEvent::ToolCallStart { id, name, input, .. }) => {
                             last_was_thinking = false;
+                            let label = crate::tool_display::tool_label(&name, &input);
+                            active_tools.insert(id, crate::tool_display::ActiveToolDisplay::new(label.clone()));
                             print!(
-                                "{COLOR_RESET}\n{COLOR_DIM}[tool: {name}]{COLOR_RESET}{COLOR_GREEN}"
+                                "{COLOR_RESET}\n{COLOR_DIM}[tool: {label}]{COLOR_RESET}{COLOR_GREEN}"
                             );
-                            lead_log!("{COLOR_RESET}\n{COLOR_DIM}[tool: {name}]{COLOR_RESET}");
+                            lead_log!("{COLOR_RESET}\n{COLOR_DIM}[tool: {label}]{COLOR_RESET}");
                         }
-                        Ok(AgentEvent::ToolCallResult { output, .. }) => {
+                        Ok(AgentEvent::ToolCallResult { id, output, .. }) => {
+                            let dur = active_tools.remove(&id).map(|t| t.elapsed());
+                            let dur_str = dur
+                                .map(|d| format!(" {}", crate::tool_display::format_duration(d)))
+                                .unwrap_or_default();
                             let mark = if output.is_ok() { "✓" } else { "✗" };
                             let color = if output.is_ok() { COLOR_DIM } else { COLOR_YELLOW };
-                            print!("{color} {mark}{COLOR_RESET}{COLOR_GREEN}");
-                            lead_log!(" {color}{mark}{COLOR_RESET}\n{COLOR_GREEN}");
+                            print!("{color} {mark}{dur_str}{COLOR_RESET}{COLOR_GREEN}");
+                            lead_log!(" {color}{mark}{dur_str}{COLOR_RESET}\n{COLOR_GREEN}");
                         }
-                        Ok(AgentEvent::ToolCallDenied { name, .. }) => {
+                        Ok(AgentEvent::ToolCallDenied { id, name, .. }) => {
+                            let dur_str = active_tools.remove(&id)
+                                .map(|t| format!(" {}", crate::tool_display::format_duration(t.elapsed())))
+                                .unwrap_or_default();
                             print!(
-                                "{COLOR_RESET}\n{COLOR_YELLOW}[denied: {name}]{COLOR_RESET}{COLOR_GREEN}"
+                                "{COLOR_RESET}\n{COLOR_YELLOW}[denied: {name}{dur_str}]{COLOR_RESET}{COLOR_GREEN}"
                             );
-                            lead_log!("{COLOR_RESET}\n{COLOR_YELLOW}[denied: {name}]{COLOR_RESET}\n{COLOR_GREEN}");
+                            lead_log!("{COLOR_RESET}\n{COLOR_YELLOW}[denied: {name}{dur_str}]{COLOR_RESET}\n{COLOR_GREEN}");
                         }
                         Ok(AgentEvent::Done { stop_reason, .. }) => {
                             print!("{COLOR_RESET}");
@@ -5035,11 +5085,21 @@ pub async fn run_repl(mut config: AppConfig) -> Result<()> {
             continue;
         }
 
+        // Immediate feedback: show spinner right after Enter.
+        print!(
+            "{}",
+            crate::tool_display::format_thinking_spinner(std::time::Duration::ZERO, 0)
+        );
+        let _ = std::io::stdout().flush();
+        let mut _early_spinner_shown = true;
+
         // `!<cmd>` shell escape — user-initiated shell command, runs
         // through BashTool (sandbox cwd, non-interactive env, etc.)
         // and prints the output. Doesn't touch agent history. Mirrors
         // the GUI handle_line path in shared_session.rs.
         if let Some(cmd) = crate::shell_bang::parse_bang(&line) {
+            print!("{}", crate::tool_display::clear_thinking_line());
+            _early_spinner_shown = false;
             println!("{COLOR_DIM}[!] {cmd}{COLOR_RESET}");
             match crate::shell_bang::run_bang_command(cmd).await {
                 Ok(output) => {
@@ -5241,6 +5301,11 @@ pub async fn run_repl(mut config: AppConfig) -> Result<()> {
         }
 
         if let Some(cmd) = parse_slash(&line) {
+            if _early_spinner_shown {
+                print!("{}", crate::tool_display::clear_thinking_line());
+                let _ = std::io::stdout().flush();
+                _early_spinner_shown = false;
+            }
             match cmd {
                 SlashCommand::Help => println!("{}", render_help()),
                 SlashCommand::Quit => break,
@@ -8763,23 +8828,76 @@ pub async fn run_repl(mut config: AppConfig) -> Result<()> {
         let mut stream = Box::pin(agent.run_turn(line.to_string()));
         let mut _cancelled = false;
         let mut last_was_thinking = false;
+        let mut active_tools: std::collections::HashMap<
+            String,
+            crate::tool_display::ActiveToolDisplay,
+        > = std::collections::HashMap::new();
+        let mut spinner_tick: u32 = 0;
+        let mut is_connecting = true;
+        let mut is_thinking_after_tool = false;
         loop {
+            let anim_delay = if is_connecting || is_thinking_after_tool || !active_tools.is_empty()
+            {
+                crate::tool_display::SPINNER_INTERVAL
+            } else {
+                std::time::Duration::from_secs(300)
+            };
             let ev = tokio::select! {
                 ev = stream.next() => ev,
                 _ = tokio::signal::ctrl_c() => {
+                    print!("{}", crate::tool_display::clear_thinking_line());
                     _cancelled = true;
                     println!("{COLOR_RESET}\n{COLOR_YELLOW}[cancelled by Ctrl-C]{COLOR_RESET}");
                     drop(stream);
                     break;
                 }
+                _ = tokio::time::sleep(anim_delay) => {
+                    spinner_tick += 1;
+                    if is_connecting {
+                        let elapsed = turn_start.elapsed();
+                        print!("{}", crate::tool_display::format_thinking_spinner(elapsed, spinner_tick));
+                        let _ = std::io::stdout().flush();
+                    } else if !active_tools.is_empty() {
+                        if let Some(id) = active_tools.iter().min_by_key(|(_, td)| td.started_at).map(|(k, _)| k.clone()) {
+                            if let Some(td) = active_tools.get_mut(&id) {
+                                print!("{}", crate::tool_display::format_tool_spinner(&td.label, td.elapsed(), spinner_tick));
+                                let _ = std::io::stdout().flush();
+                                td.last_heartbeat_at = std::time::Instant::now();
+                            }
+                        }
+                    } else if is_thinking_after_tool {
+                        let elapsed = turn_start.elapsed();
+                        print!("{}", crate::tool_display::format_thinking_spinner(elapsed, spinner_tick));
+                        let _ = std::io::stdout().flush();
+                    }
+                    continue;
+                }
             };
             let Some(ev) = ev else { break };
+            let is_tool_display =
+                matches!(&ev, Ok(AgentEvent::Text(s)) if s.starts_with("\r\x1b[2K\x1b[2m  "));
+            let is_content_event = !is_tool_display
+                && matches!(
+                    &ev,
+                    Ok(AgentEvent::Text(_))
+                        | Ok(AgentEvent::Thinking(_))
+                        | Ok(AgentEvent::ToolCallStart { .. })
+                        | Ok(AgentEvent::ToolCallResult { .. })
+                        | Err(_)
+                );
+            if (is_connecting || is_thinking_after_tool) && is_content_event {
+                if !matches!(&ev, Ok(AgentEvent::ToolCallStart { .. })) {
+                    print!("{}", crate::tool_display::clear_thinking_line());
+                    print!("{COLOR_RESET}");
+                    let _ = std::io::stdout().flush();
+                }
+                is_connecting = false;
+                is_thinking_after_tool = false;
+                spinner_tick = 0;
+            }
             match ev {
                 Ok(AgentEvent::IterationStart { .. }) => {}
                 Ok(AgentEvent::UserMessageInjected { text }) => {
-                    // Mid-turn user message landed at the tool_result
-                    // boundary (issue #106). Surface inline so the
-                    // CLI user sees their steering was applied.
                     println!("\n{COLOR_DIM}[injected mid-turn]{COLOR_RESET} {text}");
                     let _ = std::io::stdout().flush();
                 }
@@ -8788,9 +8906,36 @@ pub async fn run_repl(mut config: AppConfig) -> Result<()> {
                         println!();
                         last_was_thinking = false;
                     }
-                    print!("{s}");
+                    let is_td = s.starts_with("\r\x1b[2K\x1b[2m  ");
+                    if is_td {
+                        print!("{s}");
+                        let _ = std::io::stdout().flush();
+                        if s.contains('✓') || s.contains('✗') {
+                            is_thinking_after_tool = true;
+                            spinner_tick = 0;
+                            print!(
+                                "{}",
+                                crate::tool_display::format_thinking_spinner(
+                                    turn_start.elapsed(),
+                                    0
+                                )
+                            );
+                            let _ = std::io::stdout().flush();
+                        }
+                    } else if !s.starts_with('\r') && !s.starts_with('\x1b') && s.len() > 80 {
+                        let chars: Vec<char> = s.chars().collect();
+                        for chunk in chars.chunks(10) {
+                            for ch in chunk {
+                                print!("{ch}");
+                            }
+                            let _ = std::io::stdout().flush();
+                            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+                        }
+                    } else {
+                        print!("{s}");
+                        let _ = std::io::stdout().flush();
+                    }
                     lead_log!("{s}");
-                    let _ = std::io::stdout().flush();
                 }
                 Ok(AgentEvent::Thinking(s)) => {
                     // Dim-italic so reasoning is visibly distinct from
@@ -8799,75 +8944,63 @@ pub async fn run_repl(mut config: AppConfig) -> Result<()> {
                     last_was_thinking = true;
                     let _ = std::io::stdout().flush();
                 }
-                Ok(AgentEvent::ToolCallStart { name, input, .. }) => {
-                    // Tool-call line already starts with \n, so any prior
-                    // thinking is naturally separated; clear the flag.
+                Ok(AgentEvent::ToolCallStart {
+                    id, name, input, ..
+                }) => {
                     last_was_thinking = false;
-                    let detail = match name.as_str() {
-                        "Bash" => input
-                            .get("command")
-                            .and_then(|v| v.as_str())
-                            .map(|c| format!(": {}", c.chars().take(80).collect::<String>())),
-                        "Read" | "Write" | "Edit" => input
-                            .get("path")
-                            .and_then(|v| v.as_str())
-                            .map(|p| format!(": {p}")),
-                        "Glob" => input
-                            .get("pattern")
-                            .and_then(|v| v.as_str())
-                            .map(|p| format!(": {p}")),
-                        "Grep" => input
-                            .get("pattern")
-                            .and_then(|v| v.as_str())
-                            .map(|p| format!(": {p}")),
-                        "WebFetch" => input
-                            .get("url")
-                            .and_then(|v| v.as_str())
-                            .map(|u| format!(": {}", u.chars().take(60).collect::<String>())),
-                        "WebSearch" => input
-                            .get("query")
-                            .and_then(|v| v.as_str())
-                            .map(|q| format!(": {q}")),
-                        "Skill" => input
-                            .get("name")
-                            .and_then(|v| v.as_str())
-                            .map(|n| format!(": {n}")),
-                        "Task" => input
-                            .get("agent")
-                            .and_then(|v| v.as_str())
-                            .map(|a| format!(": agent={a}")),
-                        _ => None,
-                    }
-                    .unwrap_or_default();
-                    print!("{COLOR_RESET}\n{COLOR_DIM}[tool: {name}{detail}]{COLOR_RESET}");
-                    lead_log!("{COLOR_RESET}\n{COLOR_DIM}[tool: {name}{detail}]{COLOR_RESET}");
+                    let label = crate::tool_display::tool_label(&name, &input);
+                    active_tools.insert(
+                        id,
+                        crate::tool_display::ActiveToolDisplay::new(label.clone()),
+                    );
+                    print!(
+                        "{}",
+                        crate::tool_display::format_tool_spinner(
+                            &label,
+                            std::time::Duration::ZERO,
+                            0
+                        )
+                    );
+                    lead_log!("{COLOR_RESET}\n{COLOR_DIM}[tool: {label}]{COLOR_RESET}");
                     let _ = std::io::stdout().flush();
                 }
-                Ok(AgentEvent::ToolCallResult { name, output, .. }) => {
+                Ok(AgentEvent::ToolCallResult {
+                    id, name, output, ..
+                }) => {
+                    let td = active_tools.remove(&id);
+                    if td.is_none() {
+                        eprintln!("{COLOR_DIM}[tool-display] result for '{name}' (id={id}) has no matching start{COLOR_RESET}");
+                    }
+                    let dur_val = td.as_ref().map(|t| t.elapsed()).unwrap_or_default();
+                    let is_error = output.is_err();
                     match output {
                         Ok(ref body) => {
-                            // M6.38.9: surface the upstream source
-                            // next to the ✓ when the tool emits a
-                            // `Source: <engine>` line. The model can
-                            // drop it from its summary; the indicator
-                            // shows it regardless.
                             let src_suffix = crate::tools::extract_tool_source(body)
+                                .map(|s| crate::tool_display::sanitize_label_field(s))
                                 .map(|s| format!(" {COLOR_DIM}(via {s}){COLOR_RESET}"))
                                 .unwrap_or_default();
-                            print!(" {COLOR_DIM}✓{COLOR_RESET}{src_suffix}");
-                            lead_log!(" {COLOR_DIM}✓{COLOR_RESET}{src_suffix}\n{COLOR_GREEN}");
+                            let label = td.as_ref().map(|t| t.label.as_str()).unwrap_or(&name);
+                            print!(
+                                "{}{src_suffix}",
+                                crate::tool_display::format_tool_done(label, dur_val, false)
+                            );
+                            lead_log!(
+                                " {COLOR_DIM}✓ {}{COLOR_RESET}{src_suffix}\n{COLOR_GREEN}",
+                                crate::tool_display::format_duration(dur_val)
+                            );
                         }
                         Err(ref e) => {
-                            print!(" {COLOR_YELLOW}✗ {e}{COLOR_RESET}");
-                            lead_log!(" {COLOR_YELLOW}✗ {e}{COLOR_RESET}\n{COLOR_GREEN}");
+                            let label = td.as_ref().map(|t| t.label.as_str()).unwrap_or(&name);
+                            print!(
+                                "{}",
+                                crate::tool_display::format_tool_done(label, dur_val, true)
+                            );
+                            lead_log!(
+                                " {COLOR_YELLOW}✗ {} {e}{COLOR_RESET}\n{COLOR_GREEN}",
+                                crate::tool_display::format_duration(dur_val)
+                            );
                         }
                     }
-                    // CLI parity for plan-mode (M5). When a plan tool
-                    // mutates state, render the current plan as a
-                    // coloured ANSI block — analogue of the GUI
-                    // sidebar's live update. Only fires for the four
-                    // plan tools so we don't print a plan block
-                    // after every Read / Bash / Edit.
                     if PLAN_TOOL_NAMES.contains(&name.as_str()) {
                         if let Some(plan) = crate::tools::plan_state::get() {
                             let block = format_plan_for_cli(&plan);
@@ -8875,18 +9008,45 @@ pub async fn run_repl(mut config: AppConfig) -> Result<()> {
                             lead_log!("{block}");
                         }
                     }
-                    print!("{COLOR_RESET}\n{COLOR_GREEN}");
+                    if active_tools.is_empty() {
+                        is_thinking_after_tool = true;
+                        spinner_tick = 0;
+                        print!(
+                            "{}",
+                            crate::tool_display::format_thinking_spinner(turn_start.elapsed(), 0)
+                        );
+                    }
+                    print!("{COLOR_GREEN}");
                     let _ = std::io::stdout().flush();
                 }
-                Ok(AgentEvent::ToolCallDenied { name, .. }) => {
-                    println!("{COLOR_RESET}\n{COLOR_YELLOW}[denied: {name}]{COLOR_RESET}");
+                Ok(AgentEvent::ToolCallDenied { id, name, .. }) => {
+                    let td = active_tools.remove(&id);
+                    let dur_str = td
+                        .as_ref()
+                        .map(|t| format!(" {}", crate::tool_display::format_duration(t.elapsed())))
+                        .unwrap_or_default();
+                    print!("{}", crate::tool_display::clear_thinking_line());
+                    println!("{COLOR_RESET}\n{COLOR_YELLOW}[denied: {name}{dur_str}]{COLOR_RESET}");
                     lead_log!(
-                        "{COLOR_RESET}\n{COLOR_YELLOW}[denied: {name}]{COLOR_RESET}\n{COLOR_GREEN}"
+                        "{COLOR_RESET}\n{COLOR_YELLOW}[denied: {name}{dur_str}]{COLOR_RESET}\n{COLOR_GREEN}"
                     );
+                    if active_tools.is_empty() {
+                        is_thinking_after_tool = true;
+                        spinner_tick = 0;
+                        print!(
+                            "{}",
+                            crate::tool_display::format_thinking_spinner(turn_start.elapsed(), 0)
+                        );
+                    }
                     print!("{COLOR_GREEN}");
                     let _ = std::io::stdout().flush();
                 }
                 Ok(AgentEvent::Done { stop_reason, usage }) => {
+                    if is_thinking_after_tool || is_connecting {
+                        print!("{}", crate::tool_display::clear_thinking_line());
+                        is_thinking_after_tool = false;
+                        is_connecting = false;
+                    }
                     print!("{COLOR_RESET}");
                     if let Some(reason) = stop_reason {
                         if reason == "max_iterations" {

--- a/crates/core/src/shared_session.rs
+++ b/crates/core/src/shared_session.rs
@@ -3509,10 +3509,10 @@ async fn drive_turn_stream(
             }
             Ok(AgentEvent::ToolCallStart { name, input, .. }) => {
                 state.last_turn_made_tool_calls = true;
-                let label = format_tool_label(&name, &input);
+                let label = crate::tool_display::tool_label(&name, &input);
                 write_lead_log(
                     &state.lead_log,
-                    &format!("\x1b[0m\n\x1b[90m[tool: {name}]\x1b[0m "),
+                    &format!("\x1b[0m\n\x1b[90m[tool: {label}]\x1b[0m "),
                 );
                 let _ = events_tx.send(ViewEvent::ToolCallStart { name, label, input });
             }
@@ -3911,10 +3911,10 @@ async fn handle_team_messages(
                 let _ = events_tx.send(ViewEvent::UserPrompt(text));
             }
             Ok(AgentEvent::ToolCallStart { name, input, .. }) => {
-                let label = format_tool_label(&name, &input);
+                let label = crate::tool_display::tool_label(&name, &input);
                 write_lead_log(
                     &state.lead_log,
-                    &format!("\x1b[0m\n\x1b[90m[tool: {name}]\x1b[0m "),
+                    &format!("\x1b[0m\n\x1b[90m[tool: {label}]\x1b[0m "),
                 );
                 let _ = events_tx.send(ViewEvent::ToolCallStart { name, label, input });
             }
@@ -4142,11 +4142,7 @@ fn format_provider_model(provider: &str, model: &str) -> String {
 }
 
 fn sanitize_label_field(s: &str) -> String {
-    let cleaned: String = s
-        .chars()
-        .map(|c| if c.is_control() { ' ' } else { c })
-        .collect();
-    cleaned.split_whitespace().collect::<Vec<_>>().join(" ")
+    crate::tool_display::sanitize_label_field(s)
 }
 
 /// Translate the worker's `ViewEvent` into the chat envelope
@@ -4202,69 +4198,7 @@ fn view_event_to_chat_envelope(ev: &ViewEvent) -> Option<serde_json::Value> {
 }
 
 fn format_tool_label(name: &str, input: &serde_json::Value) -> String {
-    let detail = match name {
-        "Skill" => input
-            .get("name")
-            .and_then(|v| v.as_str())
-            .map(|n| format!("({n})")),
-        "Task" => input
-            .get("agent")
-            .and_then(|v| v.as_str())
-            .map(|a| format!("(agent={a})")),
-        "Bash" => input.get("command").and_then(|v| v.as_str()).map(|c| {
-            // Same control-char strip as AskUserQuestion — bash
-            // commands often contain heredocs (`<<'PY' ... PY`) whose
-            // newlines break the single-line label.
-            let cleaned = sanitize_label_field(c);
-            let first: String = cleaned.chars().take(40).collect();
-            format!(
-                "({first}{})",
-                if cleaned.chars().count() > 40 {
-                    "…"
-                } else {
-                    ""
-                }
-            )
-        }),
-        "Read" | "Write" | "Edit" => input
-            .get("path")
-            .and_then(|v| v.as_str())
-            .map(|p| format!("({p})")),
-        "Grep" | "Glob" => input
-            .get("pattern")
-            .and_then(|v| v.as_str())
-            .map(|p| format!("({p})")),
-        "WebFetch" => input
-            .get("url")
-            .and_then(|v| v.as_str())
-            .map(|u| format!("({})", u.chars().take(60).collect::<String>())),
-        "WebSearch" => input
-            .get("query")
-            .and_then(|v| v.as_str())
-            .map(|q| format!("({q})")),
-        "AskUserQuestion" => input.get("question").and_then(|v| v.as_str()).map(|q| {
-            // Strip newlines / control chars first — agents often pass
-            // multi-line prompts here, and the raw text breaks the
-            // single-line tool label in xterm.
-            let cleaned = sanitize_label_field(q);
-            let first: String = cleaned.chars().take(60).collect();
-            format!(
-                "({first}{})",
-                if cleaned.chars().count() > 60 {
-                    "..."
-                } else {
-                    ""
-                }
-            )
-        }),
-        _ => None,
-    }
-    .unwrap_or_default();
-    if detail.is_empty() {
-        name.to_string()
-    } else {
-        format!("{name} {detail}")
-    }
+    crate::tool_display::tool_label(name, input)
 }
 
 /// Placeholder provider used when the worker starts without any usable

--- a/crates/core/src/tool_display.rs
+++ b/crates/core/src/tool_display.rs
@@ -1,0 +1,587 @@
+//! Shared helpers for tool-call progress labels, duration formatting,
+//! heartbeat text, and result summaries. Used by the REPL, team loops,
+//! shared-session worker, and event renderer to avoid divergent label logic.
+
+use regex::Regex;
+use serde_json::Value;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+// ── constants ──────────────────────────────────────────────────────
+
+/// Maximum visible characters for a tool preview inside brackets.
+const PREVIEW_CAP: usize = 60;
+
+/// First heartbeat fires after this many seconds.
+pub(crate) const HEARTBEAT_FIRST_AFTER: Duration = Duration::from_secs(5);
+
+/// Subsequent heartbeats fire every this many seconds.
+pub(crate) const HEARTBEAT_EVERY: Duration = Duration::from_secs(15);
+
+/// "Thinking" heartbeat: fires when no output for this long during a turn.
+pub(crate) const THINKING_HEARTBEAT_AFTER: Duration = Duration::from_secs(10);
+
+// ── spinner ───────────────────────────────────────────────────────
+
+const SPINNER_FRAMES: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+/// Spinner animation interval — 100ms for smooth braille animation.
+pub(crate) const SPINNER_INTERVAL: Duration = Duration::from_millis(100);
+
+pub(crate) fn spinner_frame(tick: u32) -> char {
+    SPINNER_FRAMES[(tick as usize) % SPINNER_FRAMES.len()]
+}
+
+// ── secret redaction ───────────────────────────────────────────────
+
+struct RedactionPattern {
+    regex: Regex,
+    replacement: &'static str,
+}
+
+static REDACTION_PATTERNS: OnceLock<Vec<RedactionPattern>> = OnceLock::new();
+
+fn redaction_patterns() -> &'static [RedactionPattern] {
+    REDACTION_PATTERNS.get_or_init(|| {
+        vec![
+            RedactionPattern {
+                regex: Regex::new(r"(?i)\b(authorization\s*:\s*bearer\s+)[^\s;&]+").unwrap(),
+                replacement: "${1}<redacted>",
+            },
+            RedactionPattern {
+                regex: Regex::new(r"(?i)\b(bearer\s+)[^\s;&]+").unwrap(),
+                replacement: "${1}<redacted>",
+            },
+            RedactionPattern {
+                regex: Regex::new(
+                    r"(?i)(--(?:api-key|api_key|token|password|secret)(?:=|\s+))[^\s;&]+",
+                )
+                .unwrap(),
+                replacement: "${1}<redacted>",
+            },
+            RedactionPattern {
+                regex: Regex::new(
+                    r"(?i)(\w*(?:api[_-]?key|apikey|token|password|secret))=([^\s;&]+)",
+                )
+                .unwrap(),
+                replacement: "${1}=<redacted>",
+            },
+        ]
+    })
+}
+
+/// Redact known secret patterns from `s`. Patterns are intentionally
+/// key-shaped and case-insensitive so common environment and CLI flag
+/// variants are covered without matching ordinary words.
+fn redact_secrets(s: &str) -> String {
+    let mut out = s.to_string();
+    for pat in redaction_patterns() {
+        out = pat.regex.replace_all(&out, pat.replacement).into_owned();
+    }
+    out
+}
+
+#[cfg_attr(not(feature = "gui"), allow(dead_code))]
+pub(crate) fn redact_json_value(value: &Value) -> Value {
+    match value {
+        Value::String(s) => Value::String(redact_secrets(s)),
+        Value::Array(items) => Value::Array(items.iter().map(redact_json_value).collect()),
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .map(|(k, v)| (redact_secrets(k), redact_json_value(v)))
+                .collect(),
+        ),
+        _ => value.clone(),
+    }
+}
+
+// ── sanitization ───────────────────────────────────────────────────
+
+/// Strip control characters and collapse whitespace into single spaces.
+pub(crate) fn sanitize_label_field(s: &str) -> String {
+    let cleaned: String = s
+        .chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .collect();
+    cleaned.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Truncate to `cap` visible characters, appending "…" if truncated.
+fn truncate(s: &str, cap: usize) -> String {
+    if s.chars().count() <= cap {
+        s.to_string()
+    } else {
+        let taken: String = s.chars().take(cap).collect();
+        format!("{taken}…")
+    }
+}
+
+fn preview(s: &str, cap: usize) -> String {
+    truncate(&sanitize_label_field(&redact_secrets(s)), cap)
+}
+
+// ── label building ─────────────────────────────────────────────────
+
+/// Build a compact tool label suitable for inline display.
+///
+/// Returns something like:
+/// - `Bash (cargo test -p thclaws-core)`
+/// - `Read (crates/core/src/repl.rs)`
+/// - `Grep (ToolCallStart)`
+/// - `WebFetch (https://example.com/…)`
+/// - `Task (agent=dev-glm)`
+/// - fallback: `ToolName`
+pub(crate) fn tool_label(name: &str, input: &serde_json::Value) -> String {
+    let detail = match name {
+        "Bash" => input
+            .get("command")
+            .and_then(|v| v.as_str())
+            .map(|c| preview(c, PREVIEW_CAP)),
+        "Read" | "Write" | "Edit" => input
+            .get("file_path")
+            .or_else(|| input.get("path"))
+            .and_then(|v| v.as_str())
+            .map(|p| preview(p, PREVIEW_CAP)),
+        "Glob" => input
+            .get("pattern")
+            .and_then(|v| v.as_str())
+            .map(|p| preview(p, PREVIEW_CAP)),
+        "Grep" => input
+            .get("pattern")
+            .and_then(|v| v.as_str())
+            .map(|p| preview(p, PREVIEW_CAP)),
+        "WebFetch" => input
+            .get("url")
+            .and_then(|v| v.as_str())
+            .map(|u| preview(u, 60)),
+        "WebSearch" => input
+            .get("query")
+            .and_then(|v| v.as_str())
+            .map(|q| preview(q, PREVIEW_CAP)),
+        "Skill" => input
+            .get("skill")
+            .or_else(|| input.get("name"))
+            .and_then(|v| v.as_str())
+            .map(|n| preview(n, PREVIEW_CAP)),
+        "ToolSearch" => input
+            .get("query")
+            .and_then(|v| v.as_str())
+            .map(|q| preview(q, PREVIEW_CAP)),
+        "Agent" => input
+            .get("description")
+            .and_then(|v| v.as_str())
+            .map(|d| preview(d, PREVIEW_CAP)),
+        "Task" => input
+            .get("agent")
+            .and_then(|v| v.as_str())
+            .map(|a| format!("agent={}", preview(a, PREVIEW_CAP))),
+        "AskUserQuestion" => input
+            .get("question")
+            .and_then(|v| v.as_str())
+            .map(|q| preview(q, PREVIEW_CAP)),
+        _ => None,
+    };
+
+    match detail {
+        Some(d) if !d.is_empty() => format!("{name} ({d})"),
+        _ => name.to_string(),
+    }
+}
+
+// ── duration formatting ────────────────────────────────────────────
+
+pub(crate) fn format_duration(d: Duration) -> String {
+    let total_secs = d.as_secs();
+    if total_secs < 60 {
+        format!("{total_secs}s")
+    } else {
+        let mins = total_secs / 60;
+        let secs = total_secs % 60;
+        format!("{mins}m {secs:02}s")
+    }
+}
+
+// ── formatted output strings ───────────────────────────────────────
+
+/// Heartbeat text for a long-running tool.
+///
+/// Example: `[tool: Bash (sleep 60)] still running 45s`
+pub(crate) fn format_tool_heartbeat(label: &str, elapsed: Duration) -> String {
+    format!("[tool: {label}] still running {}", format_duration(elapsed))
+}
+
+/// Inline spinner line for an active tool — overwrites current line via `\r`.
+pub(crate) fn format_tool_spinner(label: &str, elapsed: Duration, tick: u32) -> String {
+    let frame = spinner_frame(tick);
+    let dur = format_duration(elapsed);
+    format!("\r\x1b[2K\x1b[2m  {frame} {label:<50} {dur}\x1b[0m")
+}
+
+/// Final completion line — clears spinner and writes ✓/✗ with newline.
+pub(crate) fn format_tool_done(label: &str, elapsed: Duration, is_error: bool) -> String {
+    let icon = if is_error { '✗' } else { '✓' };
+    let dur = format_duration(elapsed);
+    format!("\r\x1b[2K\x1b[2m  {icon} {label:<50} {dur}\x1b[0m\n")
+}
+
+/// Inline thinking spinner — overwrites current line with a brightness
+/// wave that sweeps left-to-right across the phrase and timer.
+pub(crate) fn format_thinking_spinner(elapsed: Duration, tick: u32) -> String {
+    let frame = spinner_frame(tick);
+    let dur = format_duration(elapsed);
+    let secs = elapsed.as_secs();
+    let phrase = if secs < 15 {
+        "Thinking"
+    } else if secs < 45 {
+        "Working"
+    } else {
+        "Still working"
+    };
+    let text = format!("{phrase} ({dur})");
+    let chars: Vec<char> = text.chars().collect();
+    let len = chars.len();
+    let gap = 6;
+    let wave_pos = (tick as usize) % (len + gap);
+    let spinner_color = match (tick / 3) % 4 {
+        0 => "\x1b[2;36m",
+        1 => "\x1b[36m",
+        2 => "\x1b[96m",
+        _ => "\x1b[36m",
+    };
+    let mut out = format!("\r\x1b[2K{spinner_color}  {frame}\x1b[0m ");
+    for (i, ch) in chars.iter().enumerate() {
+        let dist = wave_pos.abs_diff(i);
+        let color = if dist == 0 {
+            "\x1b[96m"
+        } else if dist <= 2 {
+            "\x1b[36m"
+        } else {
+            "\x1b[2;36m"
+        };
+        out.push_str(color);
+        out.push(*ch);
+    }
+    out.push_str("\x1b[0m");
+    out
+}
+
+/// Clear thinking line when real output arrives.
+pub(crate) fn clear_thinking_line() -> String {
+    "\r\x1b[2K".to_string()
+}
+
+// ── active tool state ──────────────────────────────────────────────
+
+/// Tracks a tool call in progress for heartbeat and duration reporting.
+#[derive(Debug, Clone)]
+pub(crate) struct ActiveToolDisplay {
+    pub label: String,
+    pub started_at: std::time::Instant,
+    pub last_heartbeat_at: std::time::Instant,
+}
+
+impl ActiveToolDisplay {
+    pub fn new(label: String) -> Self {
+        let now = std::time::Instant::now();
+        Self {
+            label,
+            started_at: now,
+            last_heartbeat_at: now,
+        }
+    }
+
+    /// Elapsed time since the tool started.
+    pub fn elapsed(&self) -> Duration {
+        self.started_at.elapsed()
+    }
+
+    /// Whether a heartbeat is due (first after `HEARTBEAT_FIRST_AFTER`,
+    /// then every `HEARTBEAT_EVERY`).
+    pub fn heartbeat_due(&self) -> bool {
+        let since_start = self.started_at.elapsed();
+        let since_last = self.last_heartbeat_at.elapsed();
+        if since_start < HEARTBEAT_FIRST_AFTER {
+            return false;
+        }
+        if self.last_heartbeat_at == self.started_at {
+            return true;
+        }
+        since_last >= HEARTBEAT_EVERY
+    }
+}
+
+/// Pick the oldest tool that is due for a heartbeat, if any.
+pub(crate) fn oldest_due_heartbeat(
+    active: &std::collections::HashMap<String, ActiveToolDisplay>,
+) -> Option<(&String, &ActiveToolDisplay)> {
+    active
+        .iter()
+        .filter(|(_, td)| td.heartbeat_due())
+        .min_by_key(|(_, td)| td.started_at)
+}
+
+/// Compute the delay until the next heartbeat should fire.
+/// Returns `HEARTBEAT_EVERY` when no tools are active. The caller can
+/// still safely poll the timer, but avoids scheduling an extreme
+/// `Duration::MAX` sleep.
+pub(crate) fn next_heartbeat_delay(
+    active: &std::collections::HashMap<String, ActiveToolDisplay>,
+) -> Duration {
+    if active.is_empty() {
+        return HEARTBEAT_EVERY;
+    }
+    active
+        .values()
+        .map(|td| {
+            let elapsed = td.started_at.elapsed();
+            if elapsed < HEARTBEAT_FIRST_AFTER {
+                HEARTBEAT_FIRST_AFTER - elapsed
+            } else if td.last_heartbeat_at == td.started_at {
+                Duration::ZERO
+            } else {
+                let since_last = td.last_heartbeat_at.elapsed();
+                if since_last >= HEARTBEAT_EVERY {
+                    Duration::ZERO
+                } else {
+                    HEARTBEAT_EVERY - since_last
+                }
+            }
+        })
+        .min()
+        .unwrap_or(Duration::MAX)
+}
+
+// ── tests ──────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn label_bash_command() {
+        let label = tool_label("Bash", &json!({"command": "cargo test -p thclaws-core"}));
+        assert!(label.starts_with("Bash ("));
+        assert!(label.contains("cargo test"));
+    }
+
+    #[test]
+    fn label_bash_truncation() {
+        let long = "x".repeat(200);
+        let label = tool_label("Bash", &json!({"command": long}));
+        assert!(label.contains('…'));
+        let inner = label
+            .strip_prefix("Bash (")
+            .unwrap()
+            .strip_suffix(')')
+            .unwrap();
+        assert!(inner.chars().count() <= PREVIEW_CAP + 1); // +1 for …
+    }
+
+    #[test]
+    fn label_read_path() {
+        let label = tool_label("Read", &json!({"path": "src/main.rs"}));
+        assert_eq!(label, "Read (src/main.rs)");
+    }
+
+    #[test]
+    fn label_edit_path() {
+        let label = tool_label("Edit", &json!({"path": "crates/core/src/repl.rs"}));
+        assert_eq!(label, "Edit (crates/core/src/repl.rs)");
+    }
+
+    #[test]
+    fn label_grep_pattern() {
+        let label = tool_label("Grep", &json!({"pattern": "ToolCallStart"}));
+        assert_eq!(label, "Grep (ToolCallStart)");
+    }
+
+    #[test]
+    fn label_webfetch_url() {
+        let label = tool_label(
+            "WebFetch",
+            &json!({"url": "https://example.com/api/v1/data"}),
+        );
+        assert!(label.starts_with("WebFetch ("));
+        assert!(label.contains("example.com"));
+    }
+
+    #[test]
+    fn label_task_agent() {
+        let label = tool_label("Task", &json!({"agent": "dev-glm"}));
+        assert_eq!(label, "Task (agent=dev-glm)");
+    }
+
+    #[test]
+    fn label_unknown_tool() {
+        let label = tool_label("FancyTool", &json!({}));
+        assert_eq!(label, "FancyTool");
+    }
+
+    #[test]
+    fn label_fallback_on_missing_field() {
+        let label = tool_label("Bash", &json!({}));
+        assert_eq!(label, "Bash");
+    }
+
+    #[test]
+    fn redact_token() {
+        let result = redact_secrets("curl -H token=abc123 https://api.example.com");
+        assert!(result.contains("token=<redacted>"));
+        assert!(!result.contains("abc123"));
+    }
+
+    #[test]
+    fn redact_bearer() {
+        let result = redact_secrets("Authorization: Bearer sk-12345");
+        assert!(result.contains("Authorization: Bearer <redacted>"));
+        assert!(!result.contains("sk-12345"));
+    }
+
+    #[test]
+    fn redact_api_key() {
+        let result = redact_secrets("api_key=deadbeef123&other=val");
+        assert!(result.contains("api_key=<redacted>"));
+        assert!(!result.contains("deadbeef"));
+        assert!(result.contains("&other=val"));
+    }
+
+    #[test]
+    fn redact_case_insensitive_and_cli_flags() {
+        let result = redact_secrets("TOKEN=abc --token def --api-key=ghi authorization:bearer jkl");
+        assert!(result.contains("TOKEN=<redacted>"));
+        assert!(result.contains("--token <redacted>"));
+        assert!(result.contains("--api-key=<redacted>"));
+        assert!(result.contains("authorization:bearer <redacted>"));
+        assert!(!result.contains("abc"));
+        assert!(!result.contains("def"));
+        assert!(!result.contains("ghi"));
+        assert!(!result.contains("jkl"));
+    }
+
+    #[test]
+    fn labels_redact_non_bash_fields() {
+        let web = tool_label(
+            "WebFetch",
+            &json!({"url": "https://example.com/?token=abc"}),
+        );
+        let grep = tool_label("Grep", &json!({"pattern": "API_KEY=secret"}));
+        let question = tool_label(
+            "AskUserQuestion",
+            &json!({"question": "Use Authorization: Bearer sk-123?"}),
+        );
+        assert!(web.contains("token=<redacted>"));
+        assert!(grep.contains("API_KEY=<redacted>"));
+        assert!(question.contains("Bearer <redacted>"));
+        assert!(!web.contains("abc"));
+        assert!(!grep.contains("secret"));
+        assert!(!question.contains("sk-123"));
+    }
+
+    #[test]
+    fn redact_json_value_redacts_nested_strings() {
+        let redacted = redact_json_value(&json!({
+            "command": "curl -H 'Authorization: Bearer sk-123'",
+            "nested": { "url": "https://example.com/?token=abc" },
+            "todos": [{ "content": "normal task", "status": "pending" }]
+        }));
+        assert_eq!(redacted["todos"][0]["content"], "normal task");
+        assert!(!redacted.to_string().contains("sk-123"));
+        assert!(!redacted.to_string().contains("token=abc"));
+    }
+
+    #[test]
+    fn redact_preserves_normal_text() {
+        let input = "cargo test --no-run";
+        assert_eq!(redact_secrets(input), input);
+    }
+
+    #[test]
+    fn sanitize_strips_control_chars() {
+        let result = sanitize_label_field("hello\nworld\ttab");
+        assert_eq!(result, "hello world tab");
+    }
+
+    #[test]
+    fn format_duration_sub_second() {
+        assert_eq!(format_duration(Duration::from_millis(300)), "0s");
+    }
+
+    #[test]
+    fn format_duration_seconds() {
+        assert_eq!(format_duration(Duration::from_secs(42)), "42s");
+    }
+
+    #[test]
+    fn format_duration_minutes_seconds() {
+        assert_eq!(format_duration(Duration::from_secs(72)), "1m 12s");
+    }
+
+    #[test]
+    fn format_tool_heartbeat_text() {
+        let text = format_tool_heartbeat("Bash (sleep 60)", Duration::from_secs(45));
+        assert!(text.contains("still running"));
+        assert!(text.contains("45s"));
+    }
+
+    #[test]
+    fn active_tool_heartbeat_not_due_immediately() {
+        let td = ActiveToolDisplay::new("test".to_string());
+        assert!(!td.heartbeat_due());
+    }
+
+    #[test]
+    fn active_tool_first_heartbeat_due_after_first_interval() {
+        let mut td = ActiveToolDisplay::new("test".to_string());
+        let start = std::time::Instant::now() - HEARTBEAT_FIRST_AFTER;
+        td.started_at = start;
+        td.last_heartbeat_at = start;
+        assert!(td.heartbeat_due());
+    }
+
+    #[test]
+    fn active_tool_second_heartbeat_waits_for_repeat_interval() {
+        let mut td = ActiveToolDisplay::new("test".to_string());
+        td.started_at = std::time::Instant::now() - HEARTBEAT_FIRST_AFTER - Duration::from_secs(1);
+        td.last_heartbeat_at = std::time::Instant::now();
+        assert!(!td.heartbeat_due());
+        td.last_heartbeat_at = std::time::Instant::now() - HEARTBEAT_EVERY;
+        assert!(td.heartbeat_due());
+    }
+
+    #[test]
+    fn next_heartbeat_delay_handles_empty_and_due() {
+        let empty = std::collections::HashMap::new();
+        assert_eq!(next_heartbeat_delay(&empty), HEARTBEAT_EVERY);
+
+        let mut active = std::collections::HashMap::new();
+        let mut td = ActiveToolDisplay::new("test".to_string());
+        let start = std::time::Instant::now() - HEARTBEAT_FIRST_AFTER;
+        td.started_at = start;
+        td.last_heartbeat_at = start;
+        active.insert("1".to_string(), td);
+        assert_eq!(next_heartbeat_delay(&active), Duration::ZERO);
+    }
+
+    #[test]
+    fn label_ask_user_question() {
+        let label = tool_label(
+            "AskUserQuestion",
+            &json!({"question": "Which library should we use?"}),
+        );
+        assert!(label.starts_with("AskUserQuestion ("));
+        assert!(label.contains("Which library"));
+    }
+
+    #[test]
+    fn label_skill_name() {
+        let label = tool_label("Skill", &json!({"name": "prp-plan"}));
+        assert_eq!(label, "Skill (prp-plan)");
+    }
+
+    #[test]
+    fn label_websearch_query() {
+        let label = tool_label("WebSearch", &json!({"query": "rust tokio select"}));
+        assert_eq!(label, "WebSearch (rust tokio select)");
+    }
+}

--- a/user-manual-th/ch11-built-in-tools.md
+++ b/user-manual-th/ch11-built-in-tools.md
@@ -204,16 +204,24 @@ turn ปกติจะมีหน้าตาแบบนี้:
 ❯ check if there's a README and show me its first section
 
 [tool: Glob: README*] ✓
-[tool: Read: README.md] ✓
+[tool: Read: README.md] ✓ 0.2s
 The README's first section is "Install" — it walks through…
 [tokens: 2100in/145out · 1.8s]
 ```
 
 - `[tool: Name: detail]` — tool ที่ถูกเรียก พร้อมพรีวิว argument
-  แบบย่อ (path แรก, คำสั่ง, URL ฯลฯ)
-- `✓` ต่อท้าย — tool ทำงานสำเร็จ
+  แบบย่อ (path แรก, คำสั่ง, URL, search query ฯลฯ) โดยค่าที่ดูเหมือน
+  secret เช่น token, API key, password และ bearer auth header จะถูก
+  redact ก่อนแสดงผล
+- `✓ <duration>` ต่อท้าย — tool ทำงานสำเร็จ พร้อมเวลาที่ใช้
 - `✗ <error>` ต่อท้าย — tool ล้มเหลว โดยโมเดลจะได้รับ error คืนและอาจ
   ลองใหม่ด้วยวิธีอื่น
+- tool ที่รันนานจะแสดง heartbeat แบบไม่ถี่เกินไป หลังประมาณ 10 วินาที
+  แล้วตามด้วยทุก ๆ ประมาณ 30 วินาทีขณะยังรันอยู่:
+
+```
+[tool: Bash (cargo test -p thclaws-core)] still running 40s
+```
 
 ## การตัด tool output
 

--- a/user-manual/ch11-built-in-tools.md
+++ b/user-manual/ch11-built-in-tools.md
@@ -208,16 +208,24 @@ A normal turn looks like:
 ❯ check if there's a README and show me its first section
 
 [tool: Glob: README*] ✓
-[tool: Read: README.md] ✓
+[tool: Read: README.md] ✓ 0.2s
 The README's first section is "Install" — it walks through…
 [tokens: 2100in/145out · 1.8s]
 ```
 
 - `[tool: Name: detail]` — tool being called with an abbreviated
-  argument preview (first path, command, URL, etc.).
-- Trailing `✓` — tool succeeded.
+  argument preview (first path, command, URL, search query, etc.).
+  Secret-looking values such as tokens, API keys, passwords, and bearer
+  auth headers are redacted before display.
+- Trailing `✓ <duration>` — tool succeeded and shows how long it ran.
 - Trailing `✗ <error>` — tool failed; the model gets the error back
   and may retry with a different approach.
+- Long-running tools emit a low-noise heartbeat after about 10 seconds,
+  then roughly every 30 seconds while still active:
+
+```
+[tool: Bash (cargo test -p thclaws-core)] still running 40s
+```
 
 ## Tool output truncation
 


### PR DESCRIPTION
## Summary

Add a shared `tool_display` module and wire it into the REPL, Agent SDK (Claude Code), OpenAI, and Codex providers for visible tool-call lifecycle tracking in terminal UIs.

Addresses the observability gap where tool execution showed only `🔧 [Bash]` with no target, elapsed time, or progress indication.

## Features

- **Rich tool labels**: `[tool: Bash (cargo test...)]` instead of bare `[tool: Bash]`
- **Secret redaction**: `token=`, `api_key=`, `Bearer`, compound env var names → `<redacted>`
- **Duration tracking**: `✓ Bash 12s` / `✗ Read 3s` on tool completion
- **Low-noise heartbeat**: `⏳ Bash 42s` for long-running tools (5s first, 15s repeat)
- **Braille spinner** (⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏) with gradient pulse color cycling
- **Brightness wave effect** sweeping across contextual phrases
- **Contextual phrases**: Thinking (0-15s) → Working (15-45s) → Still working (45s+)
- **Chunk-based text streaming**: 10 chars / 2ms for large text blocks (>80 chars)
- **Post-tool thinking spinner**: eliminates dead zone after tool completion
- **Immediate spinner after Enter**: no blank screen during API connect

## Safety

- MCP stdin write errors logged (not silently dropped)
- Monotonic anonymous tool ID counter (no HashMap::len() collision)
- ANSI escape injection sanitized on tool source attribution
- Orphaned tool results logged with warning

## Files Changed (11 files, +1023/-211)

| File | Change |
|------|--------|
| `tool_display.rs` | NEW: shared module — labels, redaction, duration, heartbeat, spinner, 28 tests |
| `repl.rs` | REPL event loop: spinner, streaming, tool lifecycle |
| `providers/agent_sdk.rs` | Claude Code: tool tracking, MCP error guard, heartbeat |
| `providers/openai.rs` | OpenAI: thinking heartbeat |
| `providers/openai_responses.rs` | Codex: thinking heartbeat |
| `event_render.rs` | Terminal renderer: duration, ANSI sanitization |
| `shared_session.rs` | Migrated inline labels → shared module |
| `gui.rs` | Test adjustments for redacted input |
| `lib.rs` | Export tool_display module |
| `user-manual/*.md` | Docs: tool progress section (EN + TH) |

## Test plan

- [x] `cargo build --release` — clean (1 unrelated warning)
- [x] `cargo test -p thclaws-core --lib tool_display` — 28/28 passed
- [x] Multi-agent code review (code-reviewer, security-reviewer, silent-failure-hunter) — 3 fix rounds, 0 issues
- [ ] Manual: verify rich tool labels in REPL mode
- [ ] Manual: verify heartbeat for long-running tools (>5s)
- [ ] Manual: verify secret redaction in displayed commands
- [ ] Manual: verify spinner animation + wave effect during thinking
- [ ] Manual: verify text streaming effect for long responses

Refs gobikom/agent-devops#333