### PR TITLE
feat(quiz): embed self-contained /quiz in thClaws (drop gamedev MCP)

### DIFF
--- a/crates/core/resources/quiz_player.html
+++ b/crates/core/resources/quiz_player.html
@@ -92,6 +92,9 @@ var root = document.getElementById("root");
 var S = {
   questions: Array.isArray(QUIZ.questions) ? QUIZ.questions : [],
   title: QUIZ.title || "StudyQuiz",
+  kms: QUIZ.kms || "",    // when set, offer "save score to KMS"
+  source: QUIZ.source || "",
+  saved: false,           // latch: one save per quiz run
   i: 0, score: 0, results: [], answered: false, lastOk: false,
   selected: -1, inputVal: "",
   match: null,            // {order:[], assign:[], armed:-1}
@@ -321,6 +324,51 @@ function answerText(q) {
   return "";
 }
 
+// ── save score: report the result back to the agent as a chat turn ───────
+// Emits a line-oriented [QUIZ-RESULT] payload the quiz.md prompt knows how to
+// parse and append to the KMS `_scores` page. Only meaningful when a KMS was
+// the source (S.kms set by QuizRender).
+function missedStems() {
+  var out = [];
+  for (var k = 0; k < S.questions.length; k++) {
+    if (S.results[k] === false) out.push(String(S.questions[k].stem).replace(/\s+/g, " "));
+  }
+  return out;
+}
+function resultSummaryText() {
+  var n = S.questions.length;
+  var pct = n ? Math.round(S.score / n * 100) : 0;
+  var lines = [
+    "[QUIZ-RESULT]",
+    "kms: " + S.kms,
+    "title: " + S.title,
+    "source: " + S.source,
+    "score: " + S.score + "/" + n,
+    "percent: " + pct + "%",
+    "missed:",
+  ];
+  var miss = missedStems();
+  if (miss.length === 0) lines.push("- (none)");
+  else miss.forEach(function (m) { lines.push("- " + m); });
+  return lines.join("\n");
+}
+function saveScore() {
+  if (S.saved || !S.kms) return;
+  S.saved = true;
+  // ui/message is handled as a request by the host (it calls respond(id,…)),
+  // so the message must carry a JSON-RPC id. We don't await the reply — the
+  // latch above is the idempotency guard against a double-save.
+  try {
+    parent.postMessage({
+      jsonrpc: "2.0",
+      id: "quiz-save-" + Date.now(),
+      method: "ui/message",
+      params: { content: [{ type: "text", text: resultSummaryText() }] },
+    }, "*");
+  } catch (e) {}
+  render();
+}
+
 function renderResult() {
   var n = S.questions.length;
   var pct = n ? Math.round(S.score / n * 100) : 0;
@@ -337,6 +385,12 @@ function renderResult() {
   var rev = el("button", "btn ghost", "ทบทวนคำตอบ"); rev.onclick = function () { S.review = 0; S.screen = "review"; render(); };
   var again = el("button", "btn", "เริ่มใหม่"); again.onclick = function () { S.i = 0; S.score = 0; S.results = []; S.screen = "question"; startQuestion(); render(); };
   bar.appendChild(rev); bar.appendChild(again);
+  if (S.kms) {
+    var save = el("button", "btn", S.saved ? "บันทึกแล้ว ✓" : "บันทึกคะแนนลงคลังความรู้");
+    save.disabled = S.saved;
+    save.onclick = saveScore;
+    bar.appendChild(save);
+  }
   root.appendChild(bar);
   postSize();
 }

--- a/crates/core/resources/quiz_player.html
+++ b/crates/core/resources/quiz_player.html
@@ -1,0 +1,389 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>StudyQuiz</title>
+<style>
+  :root {
+    --bg: #181826; --card: #262640; --card-hi: #33335a;
+    --text: #f2f2f7; --dim: #a6a6c0; --accent: #7c5cff;
+    --correct: #3ecf8e; --wrong: #ff6b6b;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: var(--bg); color: var(--text);
+    font-family: "Noto Sans Thai", "Sarabun", "Leelawadee UI", "Tahoma", "Segoe UI", sans-serif;
+    font-size: 16px; line-height: 1.5;
+  }
+  #root { max-width: 760px; margin: 0 auto; padding: 20px 18px 28px; }
+  .hdr { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 14px; }
+  .hdr .label { color: var(--dim); font-size: 0.9em; }
+  .dots { display: flex; gap: 7px; flex-wrap: wrap; }
+  .dot { width: 9px; height: 9px; border-radius: 50%; background: var(--card-hi); }
+  .dot.cur { background: var(--accent); }
+  .dot.ok { background: var(--correct); }
+  .dot.bad { background: var(--wrong); }
+  .stem { font-size: 1.15em; font-weight: 600; margin: 6px 0 16px; white-space: pre-wrap; }
+  .choices { display: flex; flex-direction: column; gap: 10px; }
+  .choice {
+    display: flex; align-items: center; gap: 12px; width: 100%; text-align: left;
+    background: var(--card); color: var(--text); border: 2px solid transparent;
+    border-radius: 12px; padding: 13px 15px; font: inherit; cursor: pointer;
+    transition: background .12s, border-color .12s;
+  }
+  .choice:hover:not(:disabled) { background: var(--card-hi); }
+  .choice:disabled { cursor: default; }
+  .choice .bullet { color: var(--accent); font-weight: 700; flex: 0 0 auto; min-width: 1.2em; }
+  .choice.correct { background: #1f4d3a; border-color: var(--correct); }
+  .choice.wrong { background: #4d2330; border-color: var(--wrong); }
+  .tf-row { display: flex; gap: 12px; }
+  .tf-row .choice { justify-content: center; }
+  input.short {
+    width: 100%; background: #fff; color: #181826; border: 2px solid var(--accent);
+    border-radius: 10px; padding: 12px 14px; font: inherit; outline: none;
+  }
+  .match { display: grid; grid-template-columns: 1fr 1fr; gap: 10px 14px; }
+  .match .col-h { color: var(--dim); font-size: 0.82em; margin-bottom: 2px; }
+  .mitem {
+    display: flex; align-items: center; gap: 10px; width: 100%; text-align: left;
+    background: var(--card); color: var(--text); border: 2px solid transparent;
+    border-radius: 10px; padding: 11px 13px; font: inherit; cursor: pointer; min-height: 48px;
+  }
+  .mitem:hover:not(:disabled) { background: var(--card-hi); }
+  .mitem.armed { border-color: var(--accent); background: var(--card-hi); }
+  .mitem.used { background: var(--card-hi); }
+  .mitem.correct { border-color: var(--correct); }
+  .mitem.wrong { border-color: var(--wrong); }
+  .mitem .badge { color: var(--accent); font-weight: 700; min-width: 1.3em; }
+  .hint { color: var(--dim); font-size: 0.82em; margin: 4px 0 10px; }
+  .feedback { margin-top: 16px; padding: 13px 15px; border-radius: 12px; background: var(--card); }
+  .feedback .tag { font-weight: 700; }
+  .feedback .tag.ok { color: var(--correct); }
+  .feedback .tag.bad { color: var(--wrong); }
+  .feedback .exp { color: var(--dim); margin-top: 6px; white-space: pre-wrap; }
+  .actions { display: flex; gap: 10px; justify-content: flex-end; margin-top: 18px; flex-wrap: wrap; }
+  .btn {
+    background: var(--accent); color: #fff; border: none; border-radius: 10px;
+    padding: 11px 20px; font: inherit; font-weight: 600; cursor: pointer;
+  }
+  .btn.ghost { background: var(--card-hi); }
+  .btn:disabled { background: #3a3a52; color: var(--dim); cursor: default; }
+  .result { text-align: center; padding: 18px 0; }
+  .result .score { font-size: 2.6em; font-weight: 800; margin: 10px 0 4px; }
+  .result .verdict { font-size: 1.05em; margin-bottom: 18px; }
+  .review-item { background: var(--card); border-radius: 12px; padding: 14px 16px; }
+  .review-item .ra { color: var(--correct); margin-top: 8px; white-space: pre-wrap; }
+  .review-item .exp { color: var(--dim); margin-top: 6px; white-space: pre-wrap; }
+  .title { font-size: 0.9em; color: var(--dim); }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script>
+"use strict";
+// Questions are inlined at build time by the QuizRender tool (no network,
+// no MCP). The placeholder below is replaced with a JS string literal of
+// the quiz JSON, so JSON.parse yields the quiz object.
+var QUIZ = JSON.parse(__QUIZ_DATA__);
+
+var root = document.getElementById("root");
+var S = {
+  questions: Array.isArray(QUIZ.questions) ? QUIZ.questions : [],
+  title: QUIZ.title || "StudyQuiz",
+  i: 0, score: 0, results: [], answered: false, lastOk: false,
+  selected: -1, inputVal: "",
+  match: null,            // {order:[], assign:[], armed:-1}
+  screen: "question",     // question | result | review
+  review: 0,
+};
+
+function normAns(s) {
+  return String(s == null ? "" : s).toLowerCase().trim()
+    .replace(/\s+/g, " ").replace(/[.!?,;:。．、！？]+$/, "");
+}
+function shuffled(n) {
+  var a = []; for (var i = 0; i < n; i++) a.push(i);
+  for (var i = n - 1; i > 0; i--) { var j = Math.floor(Math.random() * (i + 1)); var t = a[i]; a[i] = a[j]; a[j] = t; }
+  return a;
+}
+function curQ() { return S.questions[S.i]; }
+
+function startQuestion() {
+  S.answered = false; S.lastOk = false; S.selected = -1; S.inputVal = "";
+  var q = curQ();
+  if (q && q.type === "match") {
+    var n = q.pairs.length;
+    S.match = { order: shuffled(n), assign: new Array(n).fill(-1), armed: -1 };
+  } else { S.match = null; }
+}
+
+function gradeShort(q, val) {
+  var g = normAns(val); if (!g) return false;
+  var acc = (q.accept || []).slice(); if (q.answer) acc.push(q.answer);
+  if (acc.some(function (a) { return normAns(a) === g; })) return true;
+  var kw = q.keywords || [];
+  if (kw.length && kw.every(function (k) { return g.indexOf(normAns(k)) >= 0; })) return true;
+  return false;
+}
+function evaluate(given) {
+  var q = curQ(), ok = false;
+  if (q.type === "mcq") ok = (given === q.answer);
+  else if (q.type === "truefalse") ok = (given === q.answer);
+  else if (q.type === "short") ok = gradeShort(q, given);
+  else if (q.type === "match") {
+    ok = true;
+    for (var k = 0; k < q.pairs.length; k++) {
+      var pos = S.match.assign[k];
+      if (pos < 0 || S.match.order[pos] !== k) { ok = false; break; }
+    }
+  }
+  S.answered = true; S.lastOk = ok; S.results[S.i] = ok; if (ok) S.score++;
+  render();
+}
+function advance() {
+  if (S.i < S.questions.length - 1) { S.i++; startQuestion(); render(); }
+  else { S.screen = "result"; render(); }
+}
+
+function el(tag, cls, txt) {
+  var e = document.createElement(tag);
+  if (cls) e.className = cls;
+  if (txt != null) e.textContent = txt;
+  return e;
+}
+function letter(i) { return String.fromCharCode(65 + i); }
+
+function render() {
+  root.innerHTML = "";
+  if (S.screen === "result") return renderResult();
+  if (S.screen === "review") return renderReview();
+  renderQuestion();
+  postSize();
+}
+
+function header(labelText, reviewMode) {
+  var h = el("div", "hdr");
+  h.appendChild(el("span", "label", labelText));
+  var dots = el("div", "dots");
+  for (var k = 0; k < S.questions.length; k++) {
+    var c = "dot";
+    if (!reviewMode && k === S.i) c += " cur";
+    else if (S.results[k] === true) c += " ok";
+    else if (S.results[k] === false) c += " bad";
+    dots.appendChild(el("span", c));
+  }
+  h.appendChild(dots);
+  return h;
+}
+
+function renderQuestion() {
+  var q = curQ();
+  if (!q) { root.appendChild(el("div", "stem", "ไม่มีคำถาม")); return; }
+  root.appendChild(header("ข้อ " + (S.i + 1) + " / " + S.questions.length, false));
+  root.appendChild(el("div", "stem", q.stem));
+
+  if (q.type === "mcq") renderChoices(q, q.choices, false);
+  else if (q.type === "truefalse") renderChoices(q, ["ถูก (True)", "ผิด (False)"], true);
+  else if (q.type === "short") renderShort(q);
+  else if (q.type === "match") renderMatch(q);
+
+  if (S.answered) renderFeedback(q);
+  renderActions(q);
+}
+
+function renderChoices(q, labels, isTF) {
+  var wrap = el("div", isTF ? "choices" : "choices");
+  if (isTF) wrap.className = "tf-row";
+  var correctIdx = (q.type === "truefalse") ? (q.answer ? 0 : 1) : q.answer;
+  labels.forEach(function (lab, idx) {
+    var b = el("button", "choice");
+    if (S.answered) {
+      b.disabled = true;
+      if (idx === correctIdx) b.className += " correct";
+      else if (idx === S.selected) b.className += " wrong";
+    }
+    if (!isTF) { var bl = el("span", "bullet", letter(idx) + "."); b.appendChild(bl); }
+    b.appendChild(el("span", null, lab));
+    b.onclick = function () {
+      if (S.answered) return;
+      S.selected = idx;
+      evaluate(isTF ? (idx === 0) : idx);
+    };
+    wrap.appendChild(b);
+  });
+  root.appendChild(wrap);
+}
+
+function renderShort(q) {
+  if (S.answered) {
+    var box = el("div", "feedback");
+    box.appendChild(el("div", null, "คำตอบของคุณ: " + (S.inputVal || "—")));
+    box.appendChild(el("div", "ra", "เฉลย: " + q.answer));
+    root.appendChild(box);
+    return;
+  }
+  var inp = el("input", "short");
+  inp.type = "text"; inp.value = S.inputVal;
+  inp.setAttribute("autocomplete", "off");
+  inp.placeholder = "พิมพ์คำตอบแล้วกด Enter";
+  inp.oninput = function () { S.inputVal = inp.value; var btn = document.getElementById("primary"); if (btn) btn.disabled = normAns(inp.value).length === 0; };
+  inp.onkeydown = function (e) { if (e.key === "Enter" && normAns(inp.value).length > 0) { S.inputVal = inp.value; evaluate(inp.value); } };
+  root.appendChild(inp);
+  root.appendChild(el("div", "hint", "พิมพ์คำตอบสั้น ๆ แล้วกด Enter หรือปุ่ม “ส่งคำตอบ”"));
+  setTimeout(function () { try { inp.focus(); } catch (e) {} }, 0);
+}
+
+function renderMatch(q) {
+  root.appendChild(el("div", "hint", "เลือกข้อทางซ้าย → แล้วเลือกตัวอักษรทางขวาเพื่อจับคู่"));
+  var grid = el("div", "match");
+  var lh = el("div", "col-h", "โจทย์"); var rh = el("div", "col-h", "ตัวเลือก");
+  grid.appendChild(lh); grid.appendChild(rh);
+  var n = q.pairs.length;
+  for (var r = 0; r < n; r++) {
+    // left
+    (function (li) {
+      var left = el("button", "mitem");
+      var assignedPos = S.match.assign[li];
+      var badge = el("span", "badge", assignedPos >= 0 ? letter(assignedPos) : "—");
+      left.appendChild(badge);
+      left.appendChild(el("span", null, q.pairs[li][0]));
+      if (S.match.armed === li) left.className += " armed";
+      if (S.answered) {
+        left.disabled = true;
+        var ok = (assignedPos >= 0 && S.match.order[assignedPos] === li);
+        left.className += ok ? " correct" : " wrong";
+      } else {
+        left.onclick = function () { S.match.armed = li; render(); };
+      }
+      grid.appendChild(left);
+    })(r);
+    // right (display position r shows pairs[order[r]][1])
+    (function (ri) {
+      var origin = S.match.order[ri];
+      var right = el("button", "mitem");
+      right.appendChild(el("span", "badge", letter(ri)));
+      right.appendChild(el("span", null, q.pairs[origin][1]));
+      var usedBy = S.match.assign.indexOf(ri);
+      if (usedBy >= 0) right.className += " used";
+      if (S.answered) {
+        right.disabled = true;
+        if (usedBy >= 0) right.className += (origin === usedBy) ? " correct" : " wrong";
+      } else {
+        right.onclick = function () {
+          if (S.match.armed < 0) return;
+          for (var k = 0; k < S.match.assign.length; k++) if (S.match.assign[k] === ri) S.match.assign[k] = -1;
+          S.match.assign[S.match.armed] = ri; S.match.armed = -1; render();
+        };
+      }
+      grid.appendChild(right);
+    })(r);
+  }
+  root.appendChild(grid);
+}
+
+function renderFeedback(q) {
+  var fb = el("div", "feedback");
+  var tag = el("div", "tag " + (S.lastOk ? "ok" : "bad"), S.lastOk ? "✓ ถูกต้อง" : "✗ ยังไม่ถูก");
+  fb.appendChild(tag);
+  if (q.explanation) fb.appendChild(el("div", "exp", q.explanation));
+  root.appendChild(fb);
+}
+
+function renderActions(q) {
+  var bar = el("div", "actions");
+  if (S.answered) {
+    var last = S.i >= S.questions.length - 1;
+    var nxt = el("button", "btn", last ? "ดูผลคะแนน" : "ถัดไป ›");
+    nxt.id = "primary"; nxt.onclick = advance;
+    bar.appendChild(nxt);
+  } else if (q.type === "short") {
+    var sub = el("button", "btn", "ส่งคำตอบ");
+    sub.id = "primary"; sub.disabled = normAns(S.inputVal).length === 0;
+    sub.onclick = function () { if (normAns(S.inputVal).length > 0) evaluate(S.inputVal); };
+    bar.appendChild(sub);
+  } else if (q.type === "match") {
+    var allAssigned = S.match.assign.every(function (p) { return p >= 0; });
+    var chk = el("button", "btn", "ตรวจคำตอบ");
+    chk.id = "primary"; chk.disabled = !allAssigned;
+    chk.onclick = function () { if (S.match.assign.every(function (p) { return p >= 0; })) evaluate(null); };
+    bar.appendChild(chk);
+  }
+  root.appendChild(bar);
+}
+
+function answerText(q) {
+  if (q.type === "mcq") return q.choices[q.answer];
+  if (q.type === "truefalse") return q.answer ? "ถูก (True)" : "ผิด (False)";
+  if (q.type === "short") return q.answer;
+  if (q.type === "match") return q.pairs.map(function (p) { return p[0] + " → " + p[1]; }).join("\n");
+  return "";
+}
+
+function renderResult() {
+  var n = S.questions.length;
+  var pct = n ? Math.round(S.score / n * 100) : 0;
+  if (S.title) root.appendChild(el("div", "title", S.title));
+  var box = el("div", "result");
+  box.appendChild(el("div", "label", "สรุปผล"));
+  box.appendChild(el("div", "score", S.score + " / " + n));
+  var verdict = pct >= 80 ? "ยอดเยี่ยม! 🎉" : (pct >= 50 ? "ดีแล้ว ลองทบทวนเพิ่ม" : "ลองทบทวนแล้วทำใหม่นะ");
+  var vc = el("div", "verdict", pct + "%  ·  " + verdict);
+  vc.style.color = pct >= 80 ? "var(--correct)" : (pct >= 50 ? "var(--accent)" : "var(--wrong)");
+  box.appendChild(vc);
+  root.appendChild(box);
+  var bar = el("div", "actions"); bar.style.justifyContent = "center";
+  var rev = el("button", "btn ghost", "ทบทวนคำตอบ"); rev.onclick = function () { S.review = 0; S.screen = "review"; render(); };
+  var again = el("button", "btn", "เริ่มใหม่"); again.onclick = function () { S.i = 0; S.score = 0; S.results = []; S.screen = "question"; startQuestion(); render(); };
+  bar.appendChild(rev); bar.appendChild(again);
+  root.appendChild(bar);
+  postSize();
+}
+
+function renderReview() {
+  var q = S.questions[S.review];
+  root.appendChild(header("ทบทวน " + (S.review + 1) + " / " + S.questions.length, true));
+  var ok = S.results[S.review];
+  var tag = el("div", "tag " + (ok ? "ok" : "bad"), ok ? "✓ ตอบถูก" : "✗ ตอบผิด");
+  tag.style.fontWeight = "700"; tag.style.color = ok ? "var(--correct)" : "var(--wrong)";
+  root.appendChild(tag);
+  root.appendChild(el("div", "stem", q.stem));
+  var item = el("div", "review-item");
+  item.appendChild(el("div", "ra", "เฉลย: " + answerText(q)));
+  if (q.explanation) item.appendChild(el("div", "exp", q.explanation));
+  root.appendChild(item);
+  var bar = el("div", "actions");
+  var prev = el("button", "btn ghost", "‹ ก่อนหน้า"); prev.disabled = S.review <= 0; prev.onclick = function () { if (S.review > 0) { S.review--; render(); } };
+  var back = el("button", "btn ghost", "กลับ"); back.onclick = function () { S.screen = "result"; render(); };
+  var next = el("button", "btn ghost", "ถัดไป ›"); next.disabled = S.review >= S.questions.length - 1; next.onclick = function () { if (S.review < S.questions.length - 1) { S.review++; render(); } };
+  bar.appendChild(prev); bar.appendChild(back); bar.appendChild(next);
+  root.appendChild(bar);
+  postSize();
+}
+
+// ── auto-size: tell the host iframe how tall we are ────────────────────
+function postSize() {
+  requestAnimationFrame(function () {
+    var h = Math.ceil(document.documentElement.scrollHeight || document.body.scrollHeight || 0);
+    try {
+      parent.postMessage({ jsonrpc: "2.0", method: "ui/notifications/size-changed", params: { height: h } }, "*");
+    } catch (e) {}
+  });
+}
+if (window.ResizeObserver) {
+  try { new ResizeObserver(function () { postSize(); }).observe(document.body); } catch (e) {}
+}
+window.addEventListener("load", postSize);
+
+// ── boot ───────────────────────────────────────────────────────────────
+if (S.questions.length === 0) {
+  root.appendChild(el("div", "stem", "ไม่พบคำถาม (quiz ว่าง)"));
+  postSize();
+} else {
+  startQuestion();
+  render();
+}
+</script>
+</body>
+</html>

--- a/crates/core/src/commands.rs
+++ b/crates/core/src/commands.rs
@@ -145,10 +145,8 @@ impl CommandStore {
     /// Seeded AFTER filesystem discovery with `or_insert`, so a project or
     /// user `<name>.md` still overrides the built-in.
     fn seed_builtins(&mut self) {
-        const BUILTINS: &[(&str, &str)] = &[(
-            "quiz",
-            include_str!("default_prompts/commands/quiz.md"),
-        )];
+        const BUILTINS: &[(&str, &str)] =
+            &[("quiz", include_str!("default_prompts/commands/quiz.md"))];
         for (fallback_name, raw) in BUILTINS {
             let def = Self::parse_from_str(
                 fallback_name,
@@ -239,8 +237,14 @@ mod tests {
         store.seed_builtins();
         let q = store.get("quiz").expect("built-in /quiz should be seeded");
         assert_eq!(q.name, "quiz");
-        assert!(q.body.contains("QuizRender"), "quiz body should call QuizRender");
-        assert!(q.body.contains("$ARGUMENTS"), "quiz body should take $ARGUMENTS");
+        assert!(
+            q.body.contains("QuizRender"),
+            "quiz body should call QuizRender"
+        );
+        assert!(
+            q.body.contains("$ARGUMENTS"),
+            "quiz body should take $ARGUMENTS"
+        );
     }
 
     #[test]

--- a/crates/core/src/commands.rs
+++ b/crates/core/src/commands.rs
@@ -145,8 +145,13 @@ impl CommandStore {
     /// Seeded AFTER filesystem discovery with `or_insert`, so a project or
     /// user `<name>.md` still overrides the built-in.
     fn seed_builtins(&mut self) {
-        const BUILTINS: &[(&str, &str)] =
-            &[("quiz", include_str!("default_prompts/commands/quiz.md"))];
+        const BUILTINS: &[(&str, &str)] = &[
+            ("quiz", include_str!("default_prompts/commands/quiz.md")),
+            (
+                "quiz-result",
+                include_str!("default_prompts/commands/quiz-result.md"),
+            ),
+        ];
         for (fallback_name, raw) in BUILTINS {
             let def = Self::parse_from_str(
                 fallback_name,
@@ -244,6 +249,24 @@ mod tests {
         assert!(
             q.body.contains("$ARGUMENTS"),
             "quiz body should take $ARGUMENTS"
+        );
+    }
+
+    #[test]
+    fn builtin_quiz_result_is_seeded() {
+        let mut store = CommandStore::default();
+        store.seed_builtins();
+        let q = store
+            .get("quiz-result")
+            .expect("built-in /quiz-result should be seeded");
+        assert_eq!(q.name, "quiz-result");
+        assert!(
+            q.body.contains("_scores"),
+            "quiz-result body should read the _scores log"
+        );
+        assert!(
+            q.body.contains("$ARGUMENTS"),
+            "quiz-result body should take $ARGUMENTS"
         );
     }
 

--- a/crates/core/src/commands.rs
+++ b/crates/core/src/commands.rs
@@ -71,6 +71,9 @@ impl CommandStore {
                 store.load_dir(&dir);
             }
         }
+        // Built-ins fill any names the filesystem didn't define, so a
+        // project/user command of the same name still wins.
+        store.seed_builtins();
         store
     }
 
@@ -108,14 +111,23 @@ impl CommandStore {
 
     fn parse(path: &Path) -> Option<CommandDef> {
         let raw = std::fs::read_to_string(path).ok()?;
-        let (frontmatter, body) = parse_frontmatter(&raw);
-        let name = frontmatter.get("name").cloned().unwrap_or_else(|| {
-            path.file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("unknown")
-                .to_string()
-        });
-        Some(CommandDef {
+        let fallback = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown");
+        Some(Self::parse_from_str(fallback, &raw, path.to_path_buf()))
+    }
+
+    /// Parse a command from a raw markdown string (shared by filesystem
+    /// discovery and built-in seeding). `fallback_name` is used as the
+    /// command name when the frontmatter omits `name`.
+    fn parse_from_str(fallback_name: &str, raw: &str, source: PathBuf) -> CommandDef {
+        let (frontmatter, body) = parse_frontmatter(raw);
+        let name = frontmatter
+            .get("name")
+            .cloned()
+            .unwrap_or_else(|| fallback_name.to_string());
+        CommandDef {
             name,
             description: frontmatter.get("description").cloned().unwrap_or_default(),
             when_to_use: frontmatter
@@ -124,8 +136,27 @@ impl CommandStore {
                 .cloned()
                 .unwrap_or_default(),
             body: body.trim_start().to_string(),
-            source: path.to_path_buf(),
-        })
+            source,
+        }
+    }
+
+    /// Commands compiled into the binary so they work in any working
+    /// directory (not just repos that ship a `.claude/commands/` file).
+    /// Seeded AFTER filesystem discovery with `or_insert`, so a project or
+    /// user `<name>.md` still overrides the built-in.
+    fn seed_builtins(&mut self) {
+        const BUILTINS: &[(&str, &str)] = &[(
+            "quiz",
+            include_str!("default_prompts/commands/quiz.md"),
+        )];
+        for (fallback_name, raw) in BUILTINS {
+            let def = Self::parse_from_str(
+                fallback_name,
+                raw,
+                PathBuf::from(format!("<builtin>/{fallback_name}")),
+            );
+            self.commands.entry(def.name.clone()).or_insert(def);
+        }
     }
 
     pub fn names(&self) -> Vec<&str> {
@@ -200,5 +231,32 @@ mod tests {
             store.get("hello").unwrap().body,
             "Project version of hello."
         );
+    }
+
+    #[test]
+    fn builtin_quiz_is_seeded() {
+        let mut store = CommandStore::default();
+        store.seed_builtins();
+        let q = store.get("quiz").expect("built-in /quiz should be seeded");
+        assert_eq!(q.name, "quiz");
+        assert!(q.body.contains("QuizRender"), "quiz body should call QuizRender");
+        assert!(q.body.contains("$ARGUMENTS"), "quiz body should take $ARGUMENTS");
+    }
+
+    #[test]
+    fn filesystem_command_overrides_builtin() {
+        let mut store = CommandStore::default();
+        store.commands.insert(
+            "quiz".into(),
+            CommandDef {
+                name: "quiz".into(),
+                description: "proj".into(),
+                when_to_use: String::new(),
+                body: "OVERRIDDEN".into(),
+                source: PathBuf::from("proj/quiz.md"),
+            },
+        );
+        store.seed_builtins();
+        assert_eq!(store.get("quiz").unwrap().body, "OVERRIDDEN");
     }
 }

--- a/crates/core/src/default_prompts/commands/quiz-result.md
+++ b/crates/core/src/default_prompts/commands/quiz-result.md
@@ -1,0 +1,72 @@
+---
+name: quiz-result
+description: Analyze quiz progress over time and the weak areas to study next, from a KMS `_scores` log
+whenToUse: When the user runs /quiz-result <kms> (or /quiz-result with no argument) to review how they are doing on a knowledge base and what to revise
+---
+
+The user invoked `/quiz-result` with this argument:
+
+$ARGUMENTS
+
+Read the recorded quiz scores for a knowledge base (KMS) and give the user a
+clear, honest analysis of their **progress** and the **weak areas they should
+study next**. This is read-only — do NOT modify the `_scores` page. Answer in
+the same language as the KMS content (Thai content → Thai). Follow these steps.
+
+## 1. Pick the KMS
+
+- If `$ARGUMENTS` names a KMS (it appears in the `# Active knowledge bases`
+  section, or a probe `KmsSearch(kms: "<arg>", pattern: ".")` does NOT return
+  the error `no KMS named '<arg>' (check /kms list)`), use it.
+- If `$ARGUMENTS` is empty and one or more KMS are active, use the **first**
+  active KMS; if several are active, say which one you picked and that
+  `/quiz-result <name>` targets another.
+- If you cannot resolve a KMS, list the available ones (`KmsSearch`/the active
+  section) and ask which to analyze, then stop.
+
+## 2. Read the scores log
+
+Call `KmsRead(kms, "_scores")`.
+
+- If it returns a "No such file" error, there are **no recorded attempts yet**.
+  Tell the user to take a quiz first with `/quiz <kms>` and press
+  "บันทึกคะแนนลงคลังความรู้" on the result screen, then stop. Do not invent data.
+- Otherwise, parse the dated entries. Each looks like:
+  ```markdown
+  ## 2026-05-29 — <quiz title>
+  - Source: <source>
+  - Score: 7/10 (70%)
+  - Weak areas:
+    - <missed question stem>
+  ```
+
+## 3. Analyze (ground everything in the log — do not fabricate)
+
+- **Progress**: number of attempts and the date span; the score trend over time
+  (improving / flat / declining — compare earliest vs latest and note the
+  direction); the first, latest, best, and average percentage.
+- **Weak areas**: collect the `Weak areas` bullets across ALL attempts and
+  group similar ones. Topics that were missed **repeatedly** (in more than one
+  attempt) are the highest priority — call these out explicitly. A topic missed
+  once and then answered right later is improving, not a weak spot.
+- **Map weak areas back to the KMS**: for each priority weak area, run
+  `KmsSearch(kms, <keywords from the missed stem>)` to find which KMS page(s)
+  cover it, so the user knows exactly what to re-read. Cite as
+  `(KMS: <name>/<page>)`.
+
+## 4. Report
+
+Give a concise, scannable summary in this shape (translate the headers to the
+KMS language):
+
+- **ความก้าวหน้า** — attempts, trend (เก่งขึ้น/ทรงตัว/ถดถอย), latest vs first %,
+  average and best.
+- **จุดอ่อนที่ต้องทบทวน** — a prioritized list (most-repeated first); for each,
+  one line on what to study and the KMS page(s) to read.
+- **ขั้นต่อไป** — concrete next actions, e.g. re-read the cited pages, ask the
+  knowledge base about a weak topic in chat, or run `/quiz <kms>` again to
+  retest. If a single weak topic dominates, suggest focusing the next quiz on
+  it.
+
+Keep it short and actionable — the goal is to tell the learner what to do next,
+not to dump the raw log.

--- a/crates/core/src/default_prompts/commands/quiz.md
+++ b/crates/core/src/default_prompts/commands/quiz.md
@@ -1,7 +1,7 @@
 ---
 name: quiz
-description: Generate and play an interactive study quiz from a URL, file, or topic
-whenToUse: When the user runs /quiz <topic|url|file> to build a playable study quiz
+description: Generate and play an interactive study quiz from a KMS knowledge base, URL, file, or topic — and record the score back into the KMS
+whenToUse: When the user runs /quiz <kms|topic|url|file> to build a playable study quiz, or /quiz with no argument to quiz the active knowledge base
 ---
 
 The user invoked `/quiz` with this argument:
@@ -11,24 +11,62 @@ $ARGUMENTS
 Build and launch an interactive **study quiz** as a playable widget. The quiz
 renders in a built-in interactive widget (no external server, no files written).
 YOU generate the questions and the grading data; the widget renders and scores
-them locally. Follow these steps.
+them locally. When the quiz is drawn from a knowledge base (KMS), the player can
+also record the score back into that KMS so progress is tracked over time.
+Follow these steps.
 
 ## 1. Interpret the argument
 
-Classify `$ARGUMENTS`:
-- Starts with `http://` or `https://` → a **URL** to read.
-- Resolves to an existing local path (verify with Read / Glob / Ls) → **file(s)**.
-- Otherwise → a **topic / scope** to quiz on from your own knowledge.
+Classify `$ARGUMENTS` using this ladder — **stop at the first match**:
+
+1. Starts with `http://` or `https://` → a **URL** to read.
+2. Starts with `topic:` → force a **topic** quiz from your own knowledge (strip
+   the prefix). Use this to skip the KMS check below.
+3. Starts with `kms:` → force a **KMS** quiz (strip the prefix; the rest is the
+   KMS name).
+4. Names a **KMS** — decide this by *resolution, not guessing*: it either
+   appears in the `# Active knowledge bases` section of your system prompt, or
+   a probe call `KmsSearch(kms: "<arg>", pattern: ".")` returns **without** the
+   error `no KMS named '<arg>' (check /kms list)`. If it resolves → KMS quiz.
+   When you auto-resolve a *bare* name to a KMS this way, print one line first:
+   `กำลังออกข้อสอบจากคลังความรู้ '<name>' — ถ้าต้องการ quiz หัวข้อทั่วไปแทน พิมพ์ /quiz topic: <name>`
+5. Resolves to an existing local path (verify with Read / Glob / Ls) → **file(s)**.
+6. Otherwise → a **topic / scope** to quiz on from your own knowledge.
+7. **Empty `$ARGUMENTS`**: if one or more KMS are active (listed under
+   `# Active knowledge bases`), quiz the **first** active KMS — and if several
+   are active, say which one you picked and that `/quiz <name>` targets another.
+   If none are active, ask the user what KMS, topic, URL, or file to quiz on.
 
 Also parse any inline options the user included, e.g. "10 questions", "hard",
 "mcq only", "เป็นภาษาไทย", "matching". Sensible defaults if unspecified:
 ~5–8 questions, a MIX of types (mcq, truefalse, short, match), every question
 with a short `explanation`. **Write the questions in the same language as the
-source/topic** (e.g. Thai content → Thai questions). If `$ARGUMENTS` is empty,
-ask the user what topic, URL, or file to quiz on, then continue.
+source material** (e.g. Thai content → Thai questions).
 
 ## 2. Gather the content
 
+- **KMS** → gather material **STRICTLY from the KMS — this is closed-book.** Do
+  NOT use your own knowledge for question content; a plausible-but-wrong fact
+  from memory would corrupt the test of what is actually recorded. Procedure:
+  1. Discover the pages: read the KMS index in the `# Active knowledge bases`
+     section, or run `KmsSearch(kms, pattern)` with broad keyword stems.
+  2. `KmsRead(kms, page)` each relevant page. **Skip** the underscore-prefixed
+     `_summary` and `_scores` pages — they are indexes/logs, not source material.
+  3. Build every `stem`, `answer`, `choices`, `pairs`, and `explanation` ONLY
+     from facts that appear in the pages you read. Each `explanation` should say
+     where in the KMS the answer comes from (e.g. "see KMS: <name>/<page>").
+  4. If the gathered content is too thin for a fair quiz (fewer than ~3
+     substantive facts), DO NOT invent filler. Tell the user the knowledge base
+     doesn't have enough material yet and stop. Suggest these **real** ways to
+     add content (do not invent commands — there is no `/kms write`):
+     - `/research --kms <name> <topic>` — research and save findings into it
+       (the `--kms` flag must come BEFORE the query, or /research creates a new
+       auto-named KMS instead),
+     - `/kms dump <name> <text>` — paste knowledge straight in (the KMS must be
+       attached first with `/kms use <name>`),
+     - `/kms ingest <name> <file>` — pull in a local file,
+     - or just ask in chat (e.g. "เขียนหน้าความรู้เรื่อง … ลง KMS <name>") and I
+       will write the page with `KmsWrite`.
 - **URL** → use `WebFetch` on it (this needs approval — tell the user you are
   fetching). For very large pages, read enough to cover the material.
 - **File(s)** → use `Read` (and `Glob` to expand directories/globs). For large
@@ -42,7 +80,8 @@ Produce questions matching this shape (the `QuizRender` tool validates them):
 ```json
 {
   "title": "<short quiz title>",
-  "source": "<the url, file path, or topic>",
+  "source": "<the KMS name, url, file path, or topic>",
+  "kms": "<kms name — ONLY for closed-book KMS quizzes; omit otherwise>",
   "questions": [
     {"type": "mcq", "stem": "...", "choices": ["...", "...", "...", "..."], "answer": 0, "explanation": "..."},
     {"type": "truefalse", "stem": "...", "answer": true, "explanation": "..."},
@@ -65,16 +104,78 @@ Rules:
 
 ## 4. Render the quiz
 
-Call the **`QuizRender`** tool with `{ "title": "<title>", "questions": [ ... ] }`
-(the `questions` array from step 3; `source` is optional). It mounts a
-self-contained, playable quiz widget inline in the chat — no files are written
-and no external server is used. After it returns, tell the user the quiz is
-ready to play (don't ask them to open a URL or a file).
+Call the **`QuizRender`** tool with the object from step 3. Field rules:
+- `title`: a short quiz title (for a KMS quiz, e.g. the KMS name + topic).
+- `source`: provenance. For a KMS quiz set it to `"KMS: <name>"`; for a URL /
+  file / topic quiz set it to that URL / path / topic.
+- `kms`: set this to the KMS name **only** for closed-book KMS quizzes. This is
+  what makes the widget show a "save score" button that records the attempt.
+  **Omit `kms`** for URL / file / topic quizzes (their scores stay ephemeral).
 
-## 5. CLI fallback (no GUI widget)
+It mounts a self-contained, playable quiz widget inline in the chat — no files
+are written and no external server is used. After it returns, tell the user the
+quiz is ready to play (don't ask them to open a URL or a file). For a KMS quiz,
+also mention they can press "บันทึกคะแนนลงคลังความรู้" on the result screen to save their score.
+
+## 5. Recording a quiz score into the KMS
+
+When you receive a user message whose **first line is exactly `[QUIZ-RESULT]`**,
+it is an automated completion report from the quiz widget — NOT a normal user
+message. Do not converse about it; record it. It looks like:
+
+```
+[QUIZ-RESULT]
+kms: <name>
+title: <quiz title>
+source: <source>
+score: 7/10
+percent: 70%
+missed:
+- <stem of a missed question>
+- ...
+```
+
+Steps:
+1. Parse `kms`, `title`, `source`, `score`, `percent`, and the `missed:` list.
+2. Tell the user you are saving (e.g. `กำลังบันทึกคะแนน…`) so the upcoming write
+   approval isn't a surprise.
+3. If the `_scores` page does not exist yet (a `KmsRead(kms, "_scores")` returns
+   a "No such file" error), first create it with `KmsWrite(kms, "_scores", …)`
+   using this seeded page, then append the entry:
+   ```markdown
+   ---
+   title: "Quiz scores"
+   topic: "Progress log of quiz attempts against this knowledge base"
+   type: quiz-scores
+   sources: []
+   ---
+
+   Auto-maintained log of /quiz attempts. Each entry records date, quiz
+   title/source, score, and weak areas.
+   ```
+   If `_scores` already exists, skip straight to the append.
+4. Append a dated entry with `KmsAppend(kms, "_scores", …)` in this exact format
+   (use today's date; list each missed stem as a `Weak areas` bullet, or
+   `- Weak areas: none 🎉` when nothing was missed):
+   ```markdown
+
+   ## <YYYY-MM-DD> — <quiz title>
+   - Source: <source>
+   - Score: 7/10 (70%)
+   - Weak areas:
+     - <missed stem 1>
+     - <missed stem 2>
+   ```
+5. Confirm in one short Thai sentence, e.g.
+   `บันทึกคะแนน 7/10 (70%) ลงคลังความรู้ '<kms>' แล้ว`.
+
+## 6. CLI fallback (no GUI widget)
 
 If you are running in the terminal / CLI where the widget cannot render, do NOT
 call `QuizRender`. Instead run the quiz **conversationally**: present one
 question at a time, accept the user's typed answer, grade it with the same rules
 as the schema, reveal the `explanation`, then continue. Report the final score
-at the end.
+at the end. There is no widget and therefore no "save score" button — so if this
+was a **KMS** quiz, record the score yourself: after grading, follow the §5
+procedure (you already know the `kms`, title, source, score, and which questions
+were missed) to write the entry into the KMS `_scores` page, then confirm.

--- a/crates/core/src/default_prompts/commands/quiz.md
+++ b/crates/core/src/default_prompts/commands/quiz.md
@@ -1,0 +1,80 @@
+---
+name: quiz
+description: Generate and play an interactive study quiz from a URL, file, or topic
+whenToUse: When the user runs /quiz <topic|url|file> to build a playable study quiz
+---
+
+The user invoked `/quiz` with this argument:
+
+$ARGUMENTS
+
+Build and launch an interactive **study quiz** as a playable widget. The quiz
+renders in a built-in interactive widget (no external server, no files written).
+YOU generate the questions and the grading data; the widget renders and scores
+them locally. Follow these steps.
+
+## 1. Interpret the argument
+
+Classify `$ARGUMENTS`:
+- Starts with `http://` or `https://` → a **URL** to read.
+- Resolves to an existing local path (verify with Read / Glob / Ls) → **file(s)**.
+- Otherwise → a **topic / scope** to quiz on from your own knowledge.
+
+Also parse any inline options the user included, e.g. "10 questions", "hard",
+"mcq only", "เป็นภาษาไทย", "matching". Sensible defaults if unspecified:
+~5–8 questions, a MIX of types (mcq, truefalse, short, match), every question
+with a short `explanation`. **Write the questions in the same language as the
+source/topic** (e.g. Thai content → Thai questions). If `$ARGUMENTS` is empty,
+ask the user what topic, URL, or file to quiz on, then continue.
+
+## 2. Gather the content
+
+- **URL** → use `WebFetch` on it (this needs approval — tell the user you are
+  fetching). For very large pages, read enough to cover the material.
+- **File(s)** → use `Read` (and `Glob` to expand directories/globs). For large
+  files, sample representative sections rather than loading everything.
+- **Topic** → use your own knowledge; no fetch needed.
+
+## 3. Write the questions
+
+Produce questions matching this shape (the `QuizRender` tool validates them):
+
+```json
+{
+  "title": "<short quiz title>",
+  "source": "<the url, file path, or topic>",
+  "questions": [
+    {"type": "mcq", "stem": "...", "choices": ["...", "...", "...", "..."], "answer": 0, "explanation": "..."},
+    {"type": "truefalse", "stem": "...", "answer": true, "explanation": "..."},
+    {"type": "short", "stem": "...", "answer": "canonical answer", "accept": ["acceptable variant", "another"], "keywords": ["must-contain term"], "explanation": "..."},
+    {"type": "match", "stem": "Match each term to its definition", "pairs": [["L1", "R1"], ["L2", "R2"], ["L3", "R3"]], "explanation": "..."}
+  ]
+}
+```
+
+Rules:
+- `mcq`: `answer` is the **0-based index** into `choices` (give 3–4 choices).
+- `truefalse`: `answer` is a boolean.
+- `short`: grading is LOCAL — put lowercase, trimmed acceptable answers in
+  `accept` (the canonical `answer` is accepted automatically), and key terms in
+  `keywords` (a reply counts as correct if it equals an accepted answer OR
+  contains every keyword). Keep `accept`/`keywords` forgiving but not trivial.
+- `match`: `pairs` lists the CORRECT `[left, right]` pairings; the widget
+  shuffles the right column itself. Use 3–5 pairs.
+- Every question needs a self-contained `stem` and a useful `explanation`.
+
+## 4. Render the quiz
+
+Call the **`QuizRender`** tool with `{ "title": "<title>", "questions": [ ... ] }`
+(the `questions` array from step 3; `source` is optional). It mounts a
+self-contained, playable quiz widget inline in the chat — no files are written
+and no external server is used. After it returns, tell the user the quiz is
+ready to play (don't ask them to open a URL or a file).
+
+## 5. CLI fallback (no GUI widget)
+
+If you are running in the terminal / CLI where the widget cannot render, do NOT
+call `QuizRender`. Instead run the quiz **conversationally**: present one
+question at a time, accept the user's typed answer, grade it with the same rules
+as the schema, reveal the `explanation`, then continue. Report the final score
+at the end.

--- a/crates/core/src/ipc.rs
+++ b/crates/core/src/ipc.rs
@@ -2115,9 +2115,16 @@ pub fn handle_ipc(msg: Value, ctx: &IpcContext) -> bool {
             let user_cmds = crate::commands::CommandStore::discover_with_extra(
                 &crate::plugins::plugin_command_dirs(),
             );
+            // Names already shown as built-ins above (e.g. the seeded `/quiz`)
+            // must not be listed a second time as a "Custom" command.
+            let builtin_names: std::collections::HashSet<&str> =
+                crate::repl::built_in_commands().iter().map(|c| c.name).collect();
             let mut user_names: Vec<&str> = user_cmds.commands.keys().map(String::as_str).collect();
             user_names.sort();
             for name in user_names {
+                if builtin_names.contains(name) {
+                    continue;
+                }
                 if let Some(cmd) = user_cmds.get(name) {
                     entries.push(serde_json::json!({
                         "name": cmd.name,

--- a/crates/core/src/ipc.rs
+++ b/crates/core/src/ipc.rs
@@ -2117,8 +2117,10 @@ pub fn handle_ipc(msg: Value, ctx: &IpcContext) -> bool {
             );
             // Names already shown as built-ins above (e.g. the seeded `/quiz`)
             // must not be listed a second time as a "Custom" command.
-            let builtin_names: std::collections::HashSet<&str> =
-                crate::repl::built_in_commands().iter().map(|c| c.name).collect();
+            let builtin_names: std::collections::HashSet<&str> = crate::repl::built_in_commands()
+                .iter()
+                .map(|c| c.name)
+                .collect();
             let mut user_names: Vec<&str> = user_cmds.commands.keys().map(String::as_str).collect();
             user_names.sort();
             for name in user_names {

--- a/crates/core/src/repl.rs
+++ b/crates/core/src/repl.rs
@@ -3026,6 +3026,9 @@ pub fn built_in_commands() -> &'static [BuiltInCommand] {
         // Deploy
         BuiltInCommand { name: "deploy",   description: "Ship .thclaws/ to a remote pod (dev-plan/28)", category: "Deploy", usage: "[--pod URL] [--token T] [--dry-run] [--full] [--no-restart]" },
 
+        // Learn
+        BuiltInCommand { name: "quiz",     description: "Generate & play a study quiz from a URL, file, or topic", category: "Learn", usage: "<topic|url|file>" },
+
         // System
         BuiltInCommand { name: "help",     description: "Show this help",                             category: "System", usage: "" },
         BuiltInCommand { name: "version",  description: "Show version",                               category: "System", usage: "" },

--- a/crates/core/src/tools/mod.rs
+++ b/crates/core/src/tools/mod.rs
@@ -31,6 +31,7 @@ pub mod plan_state;
 pub mod pptx_create;
 pub mod pptx_edit;
 pub mod pptx_read;
+pub mod quiz_render;
 pub mod read;
 pub mod search;
 pub mod session_rename;
@@ -64,6 +65,7 @@ pub use plan::{EnterPlanModeTool, ExitPlanModeTool, SubmitPlanTool, UpdatePlanSt
 pub use pptx_create::PptxCreateTool;
 pub use pptx_edit::PptxEditTool;
 pub use pptx_read::PptxReadTool;
+pub use quiz_render::QuizRenderTool;
 pub use read::ReadTool;
 pub use search::WebSearchTool;
 pub use session_rename::SessionRenameTool;
@@ -201,6 +203,7 @@ impl ToolRegistry {
         r.register(Arc::new(WebScrapeTool::new()));
         r.register(Arc::new(AskUserTool));
         r.register(Arc::new(TodoWriteTool));
+        r.register(Arc::new(QuizRenderTool::new()));
         r.register(Arc::new(EnterPlanModeTool));
         r.register(Arc::new(ExitPlanModeTool));
         r.register(Arc::new(SubmitPlanTool));
@@ -400,6 +403,7 @@ mod tests {
                 "PptxCreate",
                 "PptxEdit",
                 "PptxRead",
+                "QuizRender",
                 "Read",
                 "SubmitPlan",
                 "TodoWrite",

--- a/crates/core/src/tools/quiz_render.rs
+++ b/crates/core/src/tools/quiz_render.rs
@@ -1,0 +1,326 @@
+//! QuizRender — render an interactive study-quiz widget inline in chat.
+//!
+//! Fully self-contained: the agent generates the questions (LLM turn), calls
+//! this tool with `{title, questions}`, and the tool returns a `UiResource`
+//! whose `html` is a complete, offline quiz player (no MCP server, no Docker,
+//! no CDN). The questions are inlined into the HTML at build time, so a
+//! rendered widget never reads back any shared file — making it safe across
+//! concurrent sessions/windows. No files are written to disk.
+//!
+//! Supported question types (mirrors the `/quiz` prompt schema):
+//!   mcq        { stem, choices[], answer:index, explanation }
+//!   truefalse  { stem, answer:bool, explanation }
+//!   short      { stem, answer, accept[], keywords[], explanation }  (graded locally)
+//!   match      { stem, pairs:[[left,right],...], explanation }
+
+use super::{Tool, UiResource};
+use crate::error::{Error, Result};
+use async_trait::async_trait;
+use serde_json::{json, Value};
+use std::sync::Mutex;
+
+/// Self-contained player, embedded at compile time. Contains the token
+/// `__QUIZ_DATA__` (exactly once) which `call()` replaces with a JS string
+/// literal of the quiz JSON.
+const PLAYER_TEMPLATE: &str = include_str!("../../resources/quiz_player.html");
+const QUIZ_DATA_TOKEN: &str = "__QUIZ_DATA__";
+
+pub struct QuizRenderTool {
+    /// HTML built during the most recent `call()`, read back by
+    /// `fetch_ui_resource()`. The agent loop runs `call()` then
+    /// `fetch_ui_resource()` back-to-back on the same instance with no
+    /// interleaving await on this tool (same pattern as `games::play`),
+    /// so a single-slot stash is sufficient and collision-free per turn.
+    last_html: Mutex<Option<String>>,
+}
+
+impl Default for QuizRenderTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl QuizRenderTool {
+    pub fn new() -> Self {
+        Self {
+            last_html: Mutex::new(None),
+        }
+    }
+}
+
+fn value_to_string(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+fn str_list(v: Option<&Value>) -> Vec<String> {
+    v.and_then(|x| x.as_array())
+        .map(|a| a.iter().filter_map(|x| x.as_str().map(String::from)).collect())
+        .unwrap_or_default()
+}
+
+/// Validate + normalize the questions array (mirror of the JS `normalize()`
+/// in the previous StudyQuiz engine). Drops malformed entries; never panics.
+fn normalize_questions(raw: Option<&Value>) -> Vec<Value> {
+    let mut out = Vec::new();
+    let Some(arr) = raw.and_then(|v| v.as_array()) else {
+        return out;
+    };
+    for q in arr {
+        let Some(typ) = q.get("type").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let typ = typ.to_lowercase();
+        let stem = match q.get("stem").and_then(|v| v.as_str()) {
+            Some(s) if !s.trim().is_empty() => s.to_string(),
+            _ => continue,
+        };
+        let explanation = q
+            .get("explanation")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        match typ.as_str() {
+            "mcq" => {
+                let choices: Vec<String> = q
+                    .get("choices")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.iter().map(value_to_string).collect())
+                    .unwrap_or_default();
+                if choices.len() < 2 {
+                    continue;
+                }
+                let mut answer = q.get("answer").and_then(|v| v.as_i64()).unwrap_or(0);
+                if answer < 0 || answer as usize >= choices.len() {
+                    answer = 0;
+                }
+                out.push(json!({"type":"mcq","stem":stem,"choices":choices,"answer":answer,"explanation":explanation}));
+            }
+            "truefalse" | "tf" => {
+                let answer = match q.get("answer") {
+                    Some(Value::Bool(b)) => *b,
+                    Some(Value::String(s)) => s.eq_ignore_ascii_case("true"),
+                    _ => false,
+                };
+                out.push(json!({"type":"truefalse","stem":stem,"answer":answer,"explanation":explanation}));
+            }
+            "short" => {
+                let answer = q
+                    .get("answer")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let mut accept = str_list(q.get("accept"));
+                let keywords = str_list(q.get("keywords"));
+                if !answer.is_empty() {
+                    accept.push(answer.clone());
+                }
+                out.push(json!({"type":"short","stem":stem,"answer":answer,"accept":accept,"keywords":keywords,"explanation":explanation}));
+            }
+            "match" => {
+                let pairs: Vec<Vec<String>> = q
+                    .get("pairs")
+                    .and_then(|v| v.as_array())
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|p| {
+                                let pa = p.as_array()?;
+                                if pa.len() < 2 {
+                                    return None;
+                                }
+                                Some(vec![value_to_string(&pa[0]), value_to_string(&pa[1])])
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                if pairs.len() < 2 {
+                    continue;
+                }
+                out.push(json!({"type":"match","stem":stem,"pairs":pairs,"explanation":explanation}));
+            }
+            _ => continue,
+        }
+    }
+    out
+}
+
+/// Build the self-contained player HTML with the quiz inlined as a safely
+/// escaped JS string literal (defuses `</script>` and U+2028/U+2029 breakouts).
+fn build_player_html(title: &str, questions: &[Value]) -> Result<String> {
+    let quiz = json!({ "title": title, "questions": questions });
+    let inner = serde_json::to_string(&quiz)?; // the quiz JSON text
+    let literal = serde_json::to_string(&inner)? // a valid JS string literal
+        .replace('<', "\\u003c")
+        .replace('\u{2028}', "\\u2028")
+        .replace('\u{2029}', "\\u2029");
+    Ok(PLAYER_TEMPLATE.replace(QUIZ_DATA_TOKEN, &literal))
+}
+
+#[async_trait]
+impl Tool for QuizRenderTool {
+    fn name(&self) -> &'static str {
+        "QuizRender"
+    }
+
+    fn description(&self) -> &'static str {
+        "Render an interactive study-quiz widget inline in the chat from \
+         { title, questions[] }. Fully self-contained — writes no files, uses \
+         no external server. Supports mcq, truefalse, short (free-text), and \
+         match questions with local grading, per-question feedback, a score \
+         screen, and an answer review. Call this after you have generated the \
+         questions."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "title": { "type": "string", "description": "Short quiz title shown on the result screen." },
+                "source": { "type": "string", "description": "Optional provenance: the URL, file path, or topic the quiz was built from." },
+                "questions": {
+                    "type": "array",
+                    "minItems": 1,
+                    "description": "The quiz questions.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "type": { "type": "string", "enum": ["mcq", "truefalse", "short", "match"] },
+                            "stem": { "type": "string", "description": "The question text." },
+                            "choices": { "type": "array", "items": { "type": "string" }, "description": "mcq: 2–4 answer options." },
+                            "answer": { "description": "mcq: 0-based index into choices; truefalse: boolean; short: the canonical answer string." },
+                            "accept": { "type": "array", "items": { "type": "string" }, "description": "short: additional acceptable answers (normalized match)." },
+                            "keywords": { "type": "array", "items": { "type": "string" }, "description": "short: terms that must all appear to count as correct." },
+                            "pairs": { "type": "array", "items": { "type": "array", "items": { "type": "string" } }, "description": "match: correct [left,right] pairings; the widget shuffles the right column." },
+                            "explanation": { "type": "string", "description": "Shown after answering and in review." }
+                        },
+                        "required": ["type", "stem"]
+                    }
+                }
+            },
+            "required": ["title", "questions"]
+        })
+    }
+
+    fn requires_approval(&self, _input: &Value) -> bool {
+        false
+    }
+
+    async fn call(&self, input: Value) -> Result<String> {
+        let title = input
+            .get("title")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| "Quiz".to_string());
+
+        let questions = normalize_questions(input.get("questions"));
+        if questions.is_empty() {
+            return Err(Error::Tool(
+                "QuizRender: no valid questions — each needs a `type` (mcq/truefalse/short/match) \
+                 and a non-empty `stem` (mcq needs ≥2 choices; match needs ≥2 pairs)."
+                    .into(),
+            ));
+        }
+
+        let html = build_player_html(&title, &questions)?;
+        *self.last_html.lock().unwrap() = Some(html);
+
+        Ok(format!(
+            "Quiz ready: {} question(s) — \"{}\". The playable widget is shown inline in the chat.",
+            questions.len(),
+            title
+        ))
+    }
+
+    async fn fetch_ui_resource(&self) -> Option<UiResource> {
+        let html = self.last_html.lock().unwrap().clone()?;
+        Some(UiResource {
+            uri: "ui://quiz/player".to_string(),
+            html,
+            mime: Some("text/html;profile=mcp-app".to_string()),
+            allow_same_origin: false,
+            auto_size: true,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_drops_malformed_and_coerces() {
+        let raw = json!([
+            { "type": "mcq", "stem": "q1", "choices": ["a","b","c"], "answer": 9 }, // answer clamps to 0
+            { "type": "MCQ", "stem": "q1b", "choices": ["only-one"] },              // <2 choices -> dropped
+            { "type": "tf", "stem": "q2", "answer": "true" },                       // tf -> truefalse, string coerced
+            { "type": "short", "stem": "q3", "answer": "Paris", "accept": ["paris"] },
+            { "type": "match", "stem": "q4", "pairs": [["a","1"],["b","2"]] },
+            { "type": "match", "stem": "q4b", "pairs": [["a","1"]] },               // <2 pairs -> dropped
+            { "type": "bogus", "stem": "q5" },                                      // unknown -> dropped
+            { "stem": "no type" },                                                  // no type -> dropped
+            { "type": "mcq" },                                                      // no stem -> dropped
+        ]);
+        let out = normalize_questions(Some(&raw));
+        let types: Vec<&str> = out.iter().map(|q| q["type"].as_str().unwrap()).collect();
+        assert_eq!(types, vec!["mcq", "truefalse", "short", "match"]);
+        assert_eq!(out[0]["answer"].as_i64().unwrap(), 0); // clamped
+        assert_eq!(out[1]["answer"].as_bool().unwrap(), true); // "true" -> true
+        // short pushes canonical answer into accept
+        let accept: Vec<&str> = out[2]["accept"].as_array().unwrap().iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(accept.contains(&"Paris"));
+        assert!(accept.contains(&"paris"));
+    }
+
+    #[test]
+    fn build_html_inlines_and_escapes() {
+        let questions = normalize_questions(Some(&json!([
+            { "type": "mcq", "stem": "Has a </script> breakout?", "choices": ["yes","no"], "answer": 1, "explanation": "e" }
+        ])));
+        let html = build_player_html("T", &questions).unwrap();
+        // token fully substituted
+        assert!(!html.contains(QUIZ_DATA_TOKEN));
+        // the stem text survives (the player will JSON.parse it back)
+        assert!(html.contains("\\u003c/script>"));
+        // the only literal </script> is the player's own closing tag — the
+        // injected one must be escaped, so exactly one remains.
+        assert_eq!(html.matches("</script>").count(), 1);
+    }
+
+    #[tokio::test]
+    async fn call_then_fetch_returns_widget() {
+        let tool = QuizRenderTool::new();
+        // before any call, no widget
+        assert!(tool.fetch_ui_resource().await.is_none());
+        let out = tool
+            .call(json!({
+                "title": "Solar",
+                "questions": [{ "type": "mcq", "stem": "closest planet?", "choices": ["Mercury","Venus"], "answer": 0 }]
+            }))
+            .await
+            .unwrap();
+        assert!(out.contains("1 question"));
+        let ui = tool.fetch_ui_resource().await.expect("widget present after call");
+        assert!(ui.html.contains("closest planet?"));
+        assert!(!ui.allow_same_origin);
+        assert!(ui.auto_size);
+        assert_eq!(ui.uri, "ui://quiz/player");
+    }
+
+    #[tokio::test]
+    async fn call_with_no_valid_questions_errors() {
+        let tool = QuizRenderTool::new();
+        let err = tool
+            .call(json!({ "title": "x", "questions": [{ "type": "bogus", "stem": "" }] }))
+            .await;
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn does_not_require_approval() {
+        assert!(!QuizRenderTool::new().requires_approval(&json!({})));
+    }
+}

--- a/crates/core/src/tools/quiz_render.rs
+++ b/crates/core/src/tools/quiz_render.rs
@@ -155,8 +155,11 @@ fn normalize_questions(raw: Option<&Value>) -> Vec<Value> {
 
 /// Build the self-contained player HTML with the quiz inlined as a safely
 /// escaped JS string literal (defuses `</script>` and U+2028/U+2029 breakouts).
-fn build_player_html(title: &str, questions: &[Value]) -> Result<String> {
-    let quiz = json!({ "title": title, "questions": questions });
+/// `source` is provenance shown on the review/result screen; `kms` (when
+/// non-empty) is the knowledge base the quiz was drawn from — its presence is
+/// what makes the player offer a "save score" button.
+fn build_player_html(title: &str, source: &str, kms: &str, questions: &[Value]) -> Result<String> {
+    let quiz = json!({ "title": title, "source": source, "kms": kms, "questions": questions });
     let inner = serde_json::to_string(&quiz)?; // the quiz JSON text
     let literal = serde_json::to_string(&inner)? // a valid JS string literal
         .replace('<', "\\u003c")
@@ -186,6 +189,7 @@ impl Tool for QuizRenderTool {
             "properties": {
                 "title": { "type": "string", "description": "Short quiz title shown on the result screen." },
                 "source": { "type": "string", "description": "Optional provenance: the URL, file path, or topic the quiz was built from." },
+                "kms": { "type": "string", "description": "Optional knowledge-base name. Set this only for closed-book quizzes drawn from a KMS — it makes the player show a 'save score' button that records the attempt into this KMS's `_scores` page. Omit for URL/file/topic quizzes." },
                 "questions": {
                     "type": "array",
                     "minItems": 1,
@@ -221,6 +225,16 @@ impl Tool for QuizRenderTool {
             .map(str::to_string)
             .filter(|s| !s.trim().is_empty())
             .unwrap_or_else(|| "Quiz".to_string());
+        let source = input
+            .get("source")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let kms = input
+            .get("kms")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
 
         let questions = normalize_questions(input.get("questions"));
         if questions.is_empty() {
@@ -231,7 +245,7 @@ impl Tool for QuizRenderTool {
             ));
         }
 
-        let html = build_player_html(&title, &questions)?;
+        let html = build_player_html(&title, &source, &kms, &questions)?;
         *self.last_html.lock().unwrap() = Some(html);
 
         Ok(format!(
@@ -291,13 +305,48 @@ mod tests {
         let questions = normalize_questions(Some(&json!([
             { "type": "mcq", "stem": "Has a </script> breakout?", "choices": ["yes","no"], "answer": 1, "explanation": "e" }
         ])));
-        let html = build_player_html("T", &questions).unwrap();
+        let html = build_player_html("T", "", "", &questions).unwrap();
         // token fully substituted
         assert!(!html.contains(QUIZ_DATA_TOKEN));
         // the stem text survives (the player will JSON.parse it back)
         assert!(html.contains("\\u003c/script>"));
         // the only literal </script> is the player's own closing tag — the
         // injected one must be escaped, so exactly one remains.
+        assert_eq!(html.matches("</script>").count(), 1);
+    }
+
+    #[test]
+    fn build_html_inlines_kms_and_source() {
+        let questions = normalize_questions(Some(&json!([
+            { "type": "mcq", "stem": "q?", "choices": ["a","b"], "answer": 0 }
+        ])));
+        let html = build_player_html("T", "KMS: bio101", "bio101", &questions).unwrap();
+        // both provenance fields ride into the inlined quiz JSON so the
+        // save-score callback can echo them back to the agent.
+        assert!(html.contains("bio101"));
+        assert!(html.contains("KMS: bio101"));
+    }
+
+    #[test]
+    fn build_html_without_kms_keeps_empty_field() {
+        // absent kms/source -> empty strings, still a valid template (the
+        // player treats empty kms as falsy and shows no save button).
+        let questions = normalize_questions(Some(&json!([
+            { "type": "truefalse", "stem": "q?", "answer": true }
+        ])));
+        let html = build_player_html("T", "", "", &questions).unwrap();
+        assert!(!html.contains(QUIZ_DATA_TOKEN));
+        assert!(html.contains("\\\"kms\\\":\\\"\\\""));
+    }
+
+    #[test]
+    fn kms_and_source_breakouts_are_escaped() {
+        let questions = normalize_questions(Some(&json!([
+            { "type": "mcq", "stem": "q?", "choices": ["a","b"], "answer": 0 }
+        ])));
+        let html = build_player_html("T", "</script>", "</script>", &questions).unwrap();
+        // the new string fields go through the same escaping as the stem, so
+        // the player's closing tag stays the only literal one.
         assert_eq!(html.matches("</script>").count(), 1);
     }
 

--- a/crates/core/src/tools/quiz_render.rs
+++ b/crates/core/src/tools/quiz_render.rs
@@ -57,7 +57,11 @@ fn value_to_string(v: &Value) -> String {
 
 fn str_list(v: Option<&Value>) -> Vec<String> {
     v.and_then(|x| x.as_array())
-        .map(|a| a.iter().filter_map(|x| x.as_str().map(String::from)).collect())
+        .map(|a| {
+            a.iter()
+                .filter_map(|x| x.as_str().map(String::from))
+                .collect()
+        })
         .unwrap_or_default()
 }
 
@@ -139,7 +143,9 @@ fn normalize_questions(raw: Option<&Value>) -> Vec<Value> {
                 if pairs.len() < 2 {
                     continue;
                 }
-                out.push(json!({"type":"match","stem":stem,"pairs":pairs,"explanation":explanation}));
+                out.push(
+                    json!({"type":"match","stem":stem,"pairs":pairs,"explanation":explanation}),
+                );
             }
             _ => continue,
         }
@@ -269,8 +275,13 @@ mod tests {
         assert_eq!(types, vec!["mcq", "truefalse", "short", "match"]);
         assert_eq!(out[0]["answer"].as_i64().unwrap(), 0); // clamped
         assert_eq!(out[1]["answer"].as_bool().unwrap(), true); // "true" -> true
-        // short pushes canonical answer into accept
-        let accept: Vec<&str> = out[2]["accept"].as_array().unwrap().iter().map(|v| v.as_str().unwrap()).collect();
+                                                               // short pushes canonical answer into accept
+        let accept: Vec<&str> = out[2]["accept"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
         assert!(accept.contains(&"Paris"));
         assert!(accept.contains(&"paris"));
     }
@@ -303,7 +314,10 @@ mod tests {
             .await
             .unwrap();
         assert!(out.contains("1 question"));
-        let ui = tool.fetch_ui_resource().await.expect("widget present after call");
+        let ui = tool
+            .fetch_ui_resource()
+            .await
+            .expect("widget present after call");
         assert!(ui.html.contains("closest planet?"));
         assert!(!ui.allow_same_origin);
         assert!(ui.auto_size);


### PR DESCRIPTION
Replace the gamedev-MCP quiz with a fully embedded one. The agent generates the questions, then the new built-in QuizRender tool returns a self-contained HTML widget (questions inlined; no Docker/MCP/CDN, no files written) rendered via the existing McpAppIframe. Safe across concurrent sessions/windows — the widget inlines its data, so a rendered quiz never reads a shared file.

- resources/quiz_player.html: offline DOM quiz player — mcq / truefalse / short (IME + Thai friendly) / match, local grading, per-question feedback, score + review screens, Thai font stack, auto-size via size-changed postMessage
- tools/quiz_render.rs: QuizRender tool — validate/normalize {title,questions}, inline + escape (defuse </script> + U+2028/29), stash per call, return UiResource (allow_same_origin=false, auto_size=true); unit tests
- tools/mod.rs: register QuizRender + names snapshot
- default_prompts/commands/quiz.md: /quiz prompt now calls QuizRender instead of gamedev clone/write/preview
- commands.rs: built-in command seeding (seed_builtins + parse_from_str) so /quiz ships in the binary; filesystem quiz.md still overrides
- repl.rs: /quiz entry in built_in_commands (Learn); ipc.rs: dedup so /quiz lists once in the slash picker

---

## Follow-up (af9741e): close the learn loop — quiz from KMS + record scores + `/quiz-result`

Wires `/quiz` into the KMS so the whole teach/learn loop lives on one knowledge base:

```
/research → write knowledge into a KMS
edit KMS  → teacher/student add or refine knowledge
chat      → talk to the KMS like a teacher
/quiz     → test (closed-book) → record the score back into the KMS
/quiz-result → review progress + the weak areas to revise
```

No new Rust pipeline — `/quiz` stays prompt-driven, reusing the always-on KMS tools and the existing widget→host `ui/message` channel.

### What it adds

- **Quiz from a KMS (closed-book).** `/quiz <kms>` — or `/quiz` with no arg → the active KMS — generates questions **strictly from KMS pages** (`KmsSearch`/`KmsRead`) and refuses to fabricate when a KMS is too thin (the closed-book guarantee is the point: a wrong-but-plausible fact from training data would corrupt the test). Existing url/file/topic behavior is preserved.
- **kms-vs-topic disambiguation by resolution, not heuristics.** A name is a KMS iff it resolves (it appears in the system prompt's active-KMS section, or a `KmsSearch` probe does not return the `no KMS named '<x>'` error). On a name collision **KMS wins**, with a one-line notice and explicit `topic:` / `kms:` escape hatches.
- **Score persistence.** When a KMS sourced the quiz, the player shows a "บันทึกคะแนนลงคลังความรู้" button that posts a line-oriented `[QUIZ-RESULT]` summary back through `ui/message`; `quiz.md` then records a dated entry (score + weak areas) into the KMS `_scores` page via `KmsWrite`/`KmsAppend`. Works in CLI too — with no widget, the agent self-records after conversational grading.
- **`QuizRender` `kms` field.** New optional `kms` input; `source`+`kms` are now inlined into the player JSON (`source` was declared in the player but never actually passed through — fixed in passing). Backward compatible: absent `kms` → no save button.
- **New built-in `/quiz-result`.** Reads `_scores`, analyzes the score trend over time and the **recurring** weak areas (missed in more than one attempt = priority), and maps each weak area back to the KMS page(s) to revise. Read-only.

### Files (follow-up)

- `resources/quiz_player.html` — save-score button + `[QUIZ-RESULT]` summary over `ui/message` (idempotent latch)
- `tools/quiz_render.rs` — `kms` schema field, inline `source`/`kms`, +3 unit tests (inline, empty, escaping)
- `default_prompts/commands/quiz.md` — KMS classification ladder, closed-book gathering, score-recording turn, CLI fallback
- `default_prompts/commands/quiz-result.md` — new analysis command
- `commands.rs` — register `/quiz-result` in `seed_builtins` + seed test

### KMS scores page (`_scores.md`)

Underscore-prefixed like research's `_summary.md` (so it's appended, not renamed, on KMS merges). Seeded with `sources: []` frontmatter on first write; each attempt appends:

```markdown
## 2026-05-29 — <quiz title>
- Source: KMS: bio101
- Score: 7/10 (70%)
- Weak areas:
  - <missed question stem>
```

### How to test

1. `cargo run --features gui --bin thclaws`
2. `/kms new bio101` → `/kms use bio101`
3. Add content: `/research --kms bio101 <topic>` (flag before the query) or `/kms dump bio101 <text>`
4. `/quiz bio101` → confirm closed-book gather + questions in the KMS language
5. Finish → click "บันทึกคะแนนลงคลังความรู้" → an approval prompt fires (disk write) → check `.thclaws/kms/bio101/pages/_scores.md`
6. Repeat a couple of attempts, then `/quiz-result bio101` → progress + weak-area analysis
7. Edge checks: `/quiz topic: bio101` (topic quiz despite the KMS), `/quiz <url>` (no save button), `/quiz` (auto active KMS), `/quiz <empty-kms>` (refuses), `--cli` mode (agent self-records)

Unit smoke:
```sh
cd crates/core
THCLAWS_DISABLE_KEYCHAIN=1 cargo test --lib quiz
THCLAWS_DISABLE_KEYCHAIN=1 cargo test --lib commands::
```

### Notes / edge cases

- `KmsAppend`/`KmsWrite` keep `requires_approval = true`, so saving a score shows an approval prompt (intentional — the prompt warns the user first). Approval is **not** disabled.
- Multiple active KMS + no arg → first active, with a notice.
- `_scores` appears in the prompt index on later sessions (like `_summary`) — benign, suppressing it is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
