### PR TITLE
fix: clamp last_saved_count in sync() to prevent panic after /clear

### DIFF
--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -306,6 +306,9 @@ impl Session {
     /// the next save.
     pub fn sync(&mut self, messages: Vec<Message>) {
         self.messages = messages;
+        if self.last_saved_count > self.messages.len() {
+            self.last_saved_count = self.messages.len();
+        }
         self.updated_at = now_secs();
     }
 


### PR DESCRIPTION
## Summary
Fix panic in `Session::append_to` after `/clear` command.

## Root cause
`/clear` → `agent.clear_history()` empties the messages vec, but `Session.last_saved_count` retains the old value. On the next `SessionStore::save`, `append_to()` slices `messages[last_saved_count..]` which panics:

```
thread 'main' panicked at crates/core/src/session.rs:384:42:
range start index 6 out of range for slice of length 2
```

## Fix
Clamp `last_saved_count` to `messages.len()` in `sync()`:

```rust
pub fn sync(&mut self, messages: Vec<Message>) {
    self.messages = messages;
    if self.last_saved_count > self.messages.len() {
        self.last_saved_count = self.messages.len();
    }
    self.updated_at = now_secs();
}
```

## Reproduction
1. Start thclaws in `--cli` mode
2. Have a conversation (builds up messages + last_saved_count)
3. Run `/clear` (empties messages, last_saved_count stays)
4. Continue conversation (adds new messages)
5. Session auto-save triggers → **panic**

## Test
Full context cycle (/rrr → /soul-handoff → /clear → /soul-context → /context) completes without panic. Previously panicked 100% after /clear.