### PR TITLE
feat: Helm chart for self-hosted Kubernetes deployment

### DIFF
--- a/charts/thclaws/Chart.yaml
+++ b/charts/thclaws/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: thclaws
+description: thClaws AI agent harness — self-hosted --serve with optional multi-tenant mode
+type: application
+version: 0.1.0
+appVersion: "0.27.0"
+keywords:
+  - ai
+  - agent
+  - llm
+  - thclaws
+home: https://github.com/thClaws/thClaws
+sources:
+  - https://github.com/thClaws/thClaws
+maintainers:
+  - name: modtanoii

--- a/charts/thclaws/templates/NOTES.txt
+++ b/charts/thclaws/templates/NOTES.txt
@@ -1,0 +1,35 @@
+thClaws {{ include "thclaws.imageTag" . }} deployed as {{ .Release.Name }}.
+
+{{- if .Values.ingress.enabled }}
+  Access via ingress:
+  {{- range .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ (index $.Values.ingress.hosts 0).host }}{{ .path }}
+  {{- end }}
+  {{- end }}
+{{- else if eq .Values.service.type "NodePort" }}
+  export NODE_PORT=$(kubectl get svc {{ include "thclaws.fullname" . }} -n {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}")
+  export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "http://${NODE_IP}:${NODE_PORT}"
+{{- else }}
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "thclaws.fullname" . }} 8443:{{ .Values.service.port }}
+  # then open http://localhost:8443
+{{- end }}
+
+{{- if .Values.multiTenant.enabled }}
+
+Multi-tenant mode is ENABLED (max {{ .Values.multiTenant.maxUsers }} users, idle timeout {{ .Values.multiTenant.idleTimeout }}s).
+Your routing proxy must attach signed headers:
+  X-Thclaws-User, X-Thclaws-Ts, X-Thclaws-Proof
+{{- if and (not .Values.multiTenant.existingSecret) (not .Values.multiTenant.secret) }}
+
+WARNING: multiTenant.secret and multiTenant.existingSecret are both empty.
+         Set one before deploying to production.
+{{- end }}
+{{- end }}
+
+{{- if and (not .Values.apiKeys.existingSecret) (not .Values.apiKeys.anthropic) (not .Values.apiKeys.openai) (not .Values.apiKeys.gemini) }}
+
+WARNING: No API keys configured. Set apiKeys.anthropic (or existingSecret) or
+         the agent will fail to connect to any LLM provider.
+{{- end }}

--- a/charts/thclaws/templates/_helpers.tpl
+++ b/charts/thclaws/templates/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "thclaws.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "thclaws.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "thclaws.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "thclaws.labels" -}}
+helm.sh/chart: {{ include "thclaws.chart" . }}
+{{ include "thclaws.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "thclaws.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "thclaws.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "thclaws.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "thclaws.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/* Name of the Secret holding API keys */}}
+{{- define "thclaws.apiKeysSecretName" -}}
+{{- if .Values.apiKeys.existingSecret }}
+{{- .Values.apiKeys.existingSecret }}
+{{- else }}
+{{- printf "%s-api-keys" (include "thclaws.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/* Name of the Secret holding the HMAC secret */}}
+{{- define "thclaws.hmacSecretName" -}}
+{{- if .Values.multiTenant.existingSecret }}
+{{- .Values.multiTenant.existingSecret }}
+{{- else }}
+{{- printf "%s-hmac" (include "thclaws.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/* Image tag — falls back to Chart.AppVersion */}}
+{{- define "thclaws.imageTag" -}}
+{{- .Values.image.tag | default .Chart.AppVersion }}
+{{- end }}

--- a/charts/thclaws/templates/deployment.yaml
+++ b/charts/thclaws/templates/deployment.yaml
@@ -1,0 +1,150 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "thclaws.fullname" . }}
+  labels:
+    {{- include "thclaws.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "thclaws.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "thclaws.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "thclaws.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: thclaws
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ include "thclaws.imageTag" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --serve
+            - --port
+            - {{ .Values.serve.port | quote }}
+            - --bind
+            - {{ .Values.serve.bind | quote }}
+            {{- if .Values.multiTenant.enabled }}
+            - --multi-tenant
+            - --multi-tenant-max-users
+            - {{ .Values.multiTenant.maxUsers | quote }}
+            - --multi-tenant-idle-timeout
+            - {{ .Values.multiTenant.idleTimeout | quote }}
+            {{- end }}
+            {{- if .Values.guiShell.enabled }}
+            - --gui-shell
+            - {{ .Values.guiShell.id | quote }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.serve.port }}
+              protocol: TCP
+          env:
+            {{- if not .Values.apiKeys.existingSecret }}
+            {{- if .Values.apiKeys.anthropic }}
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "thclaws.fullname" . }}-api-keys
+                  key: anthropic-api-key
+            {{- end }}
+            {{- if .Values.apiKeys.openai }}
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "thclaws.fullname" . }}-api-keys
+                  key: openai-api-key
+            {{- end }}
+            {{- if .Values.apiKeys.gemini }}
+            - name: GEMINI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "thclaws.fullname" . }}-api-keys
+                  key: gemini-api-key
+            {{- end }}
+            {{- else }}
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.apiKeys.existingSecret }}
+                  key: anthropic-api-key
+                  optional: true
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.apiKeys.existingSecret }}
+                  key: openai-api-key
+                  optional: true
+            - name: GEMINI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.apiKeys.existingSecret }}
+                  key: gemini-api-key
+                  optional: true
+            {{- end }}
+            {{- if .Values.multiTenant.enabled }}
+            - name: THCLAWS_CLOUD_HMAC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "thclaws.hmacSecretName" . }}
+                  key: hmac-secret
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.workspace.persistence.enabled }}
+            - name: workspace
+              mountPath: /workspace
+            {{- end }}
+            {{- if .Values.config.persistence.enabled }}
+            - name: config
+              mountPath: /home/thclaws/.config/thclaws
+            {{- end }}
+      volumes:
+        {{- if .Values.workspace.persistence.enabled }}
+        - name: workspace
+          persistentVolumeClaim:
+            claimName: {{ .Values.workspace.persistence.existingClaim | default (printf "%s-workspace" (include "thclaws.fullname" .)) }}
+        {{- end }}
+        {{- if .Values.config.persistence.enabled }}
+        - name: config
+          persistentVolumeClaim:
+            claimName: {{ .Values.config.persistence.existingClaim | default (printf "%s-config" (include "thclaws.fullname" .)) }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/thclaws/templates/hpa.yaml
+++ b/charts/thclaws/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "thclaws.fullname" . }}
+  labels:
+    {{- include "thclaws.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "thclaws.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/charts/thclaws/templates/ingress.yaml
+++ b/charts/thclaws/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "thclaws.fullname" . }}
+  labels:
+    {{- include "thclaws.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "thclaws.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/thclaws/templates/pvc.yaml
+++ b/charts/thclaws/templates/pvc.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.workspace.persistence.enabled (not .Values.workspace.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "thclaws.fullname" . }}-workspace
+  labels:
+    {{- include "thclaws.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.workspace.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.workspace.persistence.size }}
+  {{- if .Values.workspace.persistence.storageClass }}
+  storageClassName: {{ .Values.workspace.persistence.storageClass }}
+  {{- end }}
+{{- end }}
+---
+{{- if and .Values.config.persistence.enabled (not .Values.config.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "thclaws.fullname" . }}-config
+  labels:
+    {{- include "thclaws.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.config.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.config.persistence.size }}
+  {{- if .Values.config.persistence.storageClass }}
+  storageClassName: {{ .Values.config.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/thclaws/templates/secret.yaml
+++ b/charts/thclaws/templates/secret.yaml
@@ -1,0 +1,33 @@
+{{- if not .Values.apiKeys.existingSecret }}
+{{- if or .Values.apiKeys.anthropic .Values.apiKeys.openai .Values.apiKeys.gemini }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "thclaws.fullname" . }}-api-keys
+  labels:
+    {{- include "thclaws.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- if .Values.apiKeys.anthropic }}
+  anthropic-api-key: {{ .Values.apiKeys.anthropic | quote }}
+  {{- end }}
+  {{- if .Values.apiKeys.openai }}
+  openai-api-key: {{ .Values.apiKeys.openai | quote }}
+  {{- end }}
+  {{- if .Values.apiKeys.gemini }}
+  gemini-api-key: {{ .Values.apiKeys.gemini | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}
+---
+{{- if and .Values.multiTenant.enabled (not .Values.multiTenant.existingSecret) .Values.multiTenant.secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "thclaws.fullname" . }}-hmac
+  labels:
+    {{- include "thclaws.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  hmac-secret: {{ .Values.multiTenant.secret | quote }}
+{{- end }}

--- a/charts/thclaws/templates/service.yaml
+++ b/charts/thclaws/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "thclaws.fullname" . }}
+  labels:
+    {{- include "thclaws.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "thclaws.selectorLabels" . | nindent 4 }}

--- a/charts/thclaws/templates/serviceaccount.yaml
+++ b/charts/thclaws/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "thclaws.serviceAccountName" . }}
+  labels:
+    {{- include "thclaws.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/thclaws/values.yaml
+++ b/charts/thclaws/values.yaml
@@ -1,0 +1,124 @@
+## thClaws Helm chart — default values
+
+image:
+  repository: thclaws/thclaws
+  tag: ""  # defaults to Chart.appVersion
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+## --serve flags
+serve:
+  port: 8443
+  bind: "0.0.0.0"
+
+## Multi-tenant mode (dev-plan/35)
+## Requires a routing layer (e.g. thClaws.cloud or your own proxy) that
+## attaches HMAC-signed X-Thclaws-User / X-Thclaws-Ts / X-Thclaws-Proof headers.
+multiTenant:
+  enabled: false
+  maxUsers: 100
+  ## Idle timeout before a user session is evicted (seconds)
+  idleTimeout: 3600
+  ## HMAC secret — set one of:
+  ##   secret: "plaintext-value"          (creates a new Secret)
+  ##   existingSecret: "my-k8s-secret"    (use pre-existing Secret, key must be "hmac-secret")
+  secret: ""
+  existingSecret: ""
+
+## GUI Shell (dev-plan/33)
+guiShell:
+  enabled: false
+  id: ""
+
+## LLM provider API keys
+## Set keys directly or point to a pre-existing Secret.
+## existingSecret keys must match: anthropic-api-key, openai-api-key, gemini-api-key
+apiKeys:
+  anthropic: ""
+  openai: ""
+  gemini: ""
+  existingSecret: ""
+
+## /workspace — the project directory the agent operates on.
+## In multi-tenant mode all per-user state lands under .thclaws/users/<id>/
+workspace:
+  ## Use a PersistentVolumeClaim (recommended for stateful workloads)
+  persistence:
+    enabled: true
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    ## Use an existing PVC instead of creating one
+    existingClaim: ""
+
+## ~/.config/thclaws — agent config, sessions list, model prefs, etc.
+config:
+  persistence:
+    enabled: true
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    size: 1Gi
+    existingClaim: ""
+
+service:
+  type: ClusterIP
+  port: 8443
+
+ingress:
+  enabled: false
+  className: "nginx"
+  annotations: {}
+    # nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    # nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    # cert-manager.io/cluster-issuer: "letsencrypt-prod"
+  hosts:
+    - host: thclaws.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  # - secretName: thclaws-tls
+  #   hosts:
+  #     - thclaws.example.com
+
+## Pod resource requests/limits
+resources: {}
+  # requests:
+  #   cpu: 500m
+  #   memory: 512Mi
+  # limits:
+  #   cpu: 2
+  #   memory: 2Gi
+
+## Horizontal Pod Autoscaler
+## Only useful if each replica serves a disjoint workspace (single-tenant, sharded).
+## Multi-tenant deployments should scale by increasing maxUsers instead.
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+podAnnotations: {}
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false  # thclaws writes to /workspace and ~/.config
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## What this adds

A production-ready Helm chart (`charts/thclaws`) for deploying thClaws in `--serve` mode on Kubernetes, with optional multi-tenant support (dev-plan/35).

## Chart structure

\`\`\`
charts/thclaws/
├── Chart.yaml
├── values.yaml                  # fully documented
└── templates/
    ├── _helpers.tpl
    ├── deployment.yaml
    ├── service.yaml
    ├── ingress.yaml
    ├── secret.yaml              # API keys + HMAC secret
    ├── pvc.yaml                 # workspace + config volumes
    ├── serviceaccount.yaml
    ├── hpa.yaml
    └── NOTES.txt
\`\`\`

## Single-tenant install (default)

\`\`\`bash
helm install thclaws ./charts/thclaws \
  --set apiKeys.anthropic=sk-ant-... \
  --set ingress.enabled=true \
  --set ingress.hosts[0].host=thclaws.example.com
\`\`\`

## Multi-tenant install

\`\`\`bash
helm install thclaws ./charts/thclaws \
  --set apiKeys.anthropic=sk-ant-... \
  --set multiTenant.enabled=true \
  --set multiTenant.secret=<hmac-secret> \
  --set multiTenant.maxUsers=100 \
  --set ingress.enabled=true \
  --set ingress.hosts[0].host=thclaws.example.com
\`\`\`

Multi-tenant mode passes \`--multi-tenant --multi-tenant-max-users --multi-tenant-idle-timeout\` flags and injects \`THCLAWS_CLOUD_HMAC_SECRET\` from a Kubernetes Secret.

## Routing proxy requirements

Multi-tenant mode requires a routing proxy in front of thClaws that performs HMAC signing before forwarding requests. thClaws validates the following headers on every request:

| Header | Description |
|--------|-------------|
| \`X-Thclaws-User\` | Identifier for the user session (e.g. email or user ID) |
| \`X-Thclaws-Ts\` | Unix timestamp of the request (used to prevent replay attacks) |
| \`X-Thclaws-Proof\` | HMAC-SHA256 signature of \`user:ts\` using the shared secret |

The shared secret is the value set in \`multiTenant.secret\` (or \`multiTenant.existingSecret\`), injected into the container as \`THCLAWS_CLOUD_HMAC_SECRET\`.

**Options for the routing layer:**

- **[thClaws.cloud](https://thclaws.cloud)** — managed routing layer with built-in HMAC signing, no config needed
- **Traefik** — use a [ForwardAuth middleware](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) pointing to a small auth service that signs and injects the headers
- **nginx** — use the \`auth_request\` module to delegate to a signing sidecar, then \`proxy_set_header\` to attach the signed headers before proxying to thClaws

A minimal signing service only needs to: verify the caller's identity (e.g. via session cookie or JWT), then compute \`HMAC-SHA256(secret, "<user>:<unix_ts>")\` and attach all three headers.

## Key values to configure

| Value | Default | Description |
|-------|---------|-------------|
| \`image.tag\` | Chart.appVersion | thClaws image tag |
| \`apiKeys.anthropic\` | \`""\` | Anthropic API key (or use \`apiKeys.existingSecret\`) |
| \`multiTenant.enabled\` | \`false\` | Enable multi-tenant mode |
| \`multiTenant.secret\` | \`""\` | HMAC signing secret (or \`multiTenant.existingSecret\`) |
| \`multiTenant.maxUsers\` | \`100\` | Max concurrent user sessions |
| \`workspace.persistence.size\` | \`10Gi\` | Workspace PVC size |
| \`ingress.enabled\` | \`false\` | Enable ingress |

## Security

- \`runAsNonRoot: true\`, UID/GID 1000
- \`allowPrivilegeEscalation: false\`
- Drops ALL capabilities
- \`automountServiceAccountToken: false\`
- Secrets never in values by default — use \`existingSecret\` for production

## Tested with

\`\`\`
helm lint charts/thclaws          # 0 errors
helm template charts/thclaws ...  # renders correctly for both single and multi-tenant
\`\`\`