### PR TITLE
fix(chart): address PR #135 review feedback

### DIFF
--- a/charts/thclaws/Chart.yaml
+++ b/charts/thclaws/Chart.yaml
@@ -12,5 +12,7 @@ keywords:
 home: https://github.com/thClaws/thClaws
 sources:
   - https://github.com/thClaws/thClaws
+annotations:
+  artifacthub.io/license: "MIT OR Apache-2.0"
 maintainers:
   - name: modtanoii

--- a/charts/thclaws/templates/deployment.yaml
+++ b/charts/thclaws/templates/deployment.yaml
@@ -54,22 +54,29 @@ spec:
             - name: ANTHROPIC_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "thclaws.fullname" . }}-api-keys
+                  name: {{ include "thclaws.apiKeysSecretName" . }}
                   key: anthropic-api-key
             {{- end }}
             {{- if .Values.apiKeys.openai }}
             - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "thclaws.fullname" . }}-api-keys
+                  name: {{ include "thclaws.apiKeysSecretName" . }}
                   key: openai-api-key
             {{- end }}
             {{- if .Values.apiKeys.gemini }}
             - name: GEMINI_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "thclaws.fullname" . }}-api-keys
+                  name: {{ include "thclaws.apiKeysSecretName" . }}
                   key: gemini-api-key
+            {{- end }}
+            {{- if .Values.apiKeys.openrouter }}
+            - name: OPENROUTER_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "thclaws.apiKeysSecretName" . }}
+                  key: openrouter-api-key
             {{- end }}
             {{- else }}
             - name: ANTHROPIC_API_KEY
@@ -89,6 +96,12 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.apiKeys.existingSecret }}
                   key: gemini-api-key
+                  optional: true
+            - name: OPENROUTER_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.apiKeys.existingSecret }}
+                  key: openrouter-api-key
                   optional: true
             {{- end }}
             {{- if .Values.multiTenant.enabled }}

--- a/charts/thclaws/templates/networkpolicy.yaml
+++ b/charts/thclaws/templates/networkpolicy.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "thclaws.fullname" . }}
+  labels:
+    {{- include "thclaws.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "thclaws.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: {{ .Values.serve.port }}
+      {{- if .Values.networkPolicy.ingressFrom }}
+      from:
+        {{- toYaml .Values.networkPolicy.ingressFrom | nindent 8 }}
+      {{- end }}
+  egress:
+    {{- if .Values.networkPolicy.allowDNS }}
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    ## Allow outbound HTTPS — required for LLM API calls (Anthropic, OpenAI, Gemini, OpenRouter)
+    - ports:
+        - protocol: TCP
+          port: 443
+    {{- with .Values.networkPolicy.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/thclaws/templates/secret.yaml
+++ b/charts/thclaws/templates/secret.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.apiKeys.existingSecret }}
-{{- if or .Values.apiKeys.anthropic .Values.apiKeys.openai .Values.apiKeys.gemini }}
+{{- if or .Values.apiKeys.anthropic .Values.apiKeys.openai .Values.apiKeys.gemini .Values.apiKeys.openrouter }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -16,6 +16,9 @@ stringData:
   {{- end }}
   {{- if .Values.apiKeys.gemini }}
   gemini-api-key: {{ .Values.apiKeys.gemini | quote }}
+  {{- end }}
+  {{- if .Values.apiKeys.openrouter }}
+  openrouter-api-key: {{ .Values.apiKeys.openrouter | quote }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/thclaws/values.yaml
+++ b/charts/thclaws/values.yaml
@@ -33,11 +33,12 @@ guiShell:
 
 ## LLM provider API keys
 ## Set keys directly or point to a pre-existing Secret.
-## existingSecret keys must match: anthropic-api-key, openai-api-key, gemini-api-key
+## existingSecret keys must match: anthropic-api-key, openai-api-key, gemini-api-key, openrouter-api-key
 apiKeys:
   anthropic: ""
   openai: ""
   gemini: ""
+  openrouter: ""
   existingSecret: ""
 
 ## /workspace — the project directory the agent operates on.
@@ -118,6 +119,22 @@ securityContext:
     drop:
       - ALL
   readOnlyRootFilesystem: false  # thclaws writes to /workspace and ~/.config
+
+## NetworkPolicy — restrict pod ingress/egress (requires a CNI that enforces NetworkPolicy)
+networkPolicy:
+  enabled: false
+  ## Restrict which sources may reach port 8443.
+  ## Leave empty to allow from all sources within the cluster.
+  ## Example: allow only from an ingress-nginx namespace:
+  ##   ingressFrom:
+  ##     - namespaceSelector:
+  ##         matchLabels:
+  ##           kubernetes.io/metadata.name: ingress-nginx
+  ingressFrom: []
+  ## Allow DNS egress (required for hostname resolution)
+  allowDNS: true
+  ## Additional egress rules appended verbatim
+  extraEgress: []
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
Follow-up to #135 — addresses maintainer review feedback.

## Changes

### 1. Use `thclaws.apiKeysSecretName` helper consistently (`deployment.yaml`)

The non-`existingSecret` branch was inlining `{{ include "thclaws.fullname" . }}-api-keys` directly. Replaced with `{{ include "thclaws.apiKeysSecretName" . }}` so the secret name is derived from a single source of truth (the helper already defined in `_helpers.tpl`).

### 2. Add OpenRouter API key support (`values.yaml`, `secret.yaml`, `deployment.yaml`)

Added `apiKeys.openrouter` alongside the existing `anthropic`/`openai`/`gemini` keys. Follows the same pattern: direct value creates a `Secret` entry (`openrouter-api-key`), `existingSecret` mounts it as optional.

### 3. License annotation (`Chart.yaml`)

Added `artifacthub.io/license: "MIT OR Apache-2.0"` via the `annotations` field (the correct way per Helm/ArtifactHub spec — a bare `license:` top-level field causes a strict-parse warning).

### 4. Optional NetworkPolicy (`templates/networkpolicy.yaml`)

New template, disabled by default (`networkPolicy.enabled: false`).

When enabled:
- **Ingress**: allows TCP on `serve.port` (8443) — optionally restricted to specific sources via `networkPolicy.ingressFrom`
- **Egress**: allows UDP/TCP 53 (DNS, toggle via `networkPolicy.allowDNS`) and TCP 443 (HTTPS — required for LLM API calls to Anthropic, OpenAI, Gemini, OpenRouter)
- **Extra egress**: `networkPolicy.extraEgress` for arbitrary additional rules

Example — restrict ingress to ingress-nginx only:

```yaml
networkPolicy:
  enabled: true
  ingressFrom:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: ingress-nginx
```

## Verification

```
helm lint charts/thclaws   # 1 chart linted, 0 failed, 0 warnings
```