### PR TITLE
fix: cap spinner line width to terminal columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5515,6 +5515,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thclaws-core"
 version = "0.28.0"
 dependencies = [
@@ -5563,6 +5573,7 @@ dependencies = [
  "tao",
  "tar",
  "tempfile",
+ "terminal_size",
  "thiserror 1.0.69",
  "tokio",
  "tokio-tungstenite",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -243,3 +243,11 @@ windows-sys = { version = "0.59", features = ["Win32_System_Console"] }
 # pulling it in directly avoids hand-rolling extern "C" declarations.
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+# Cross-platform terminal-size query (TIOCGWINSZ on Unix,
+# GetConsoleScreenBufferInfo on Windows). Used by
+# tool_display::format_tool_spinner to fit labels within the current
+# terminal row so spinner frames overwrite in place instead of
+# wrapping. Issue #138 / PR #139.
+[dependencies.terminal_size]
+version = "0.4"

--- a/crates/core/src/tool_display.rs
+++ b/crates/core/src/tool_display.rs
@@ -7,6 +7,27 @@ use serde_json::Value;
 use std::sync::OnceLock;
 use std::time::Duration;
 
+fn terminal_width() -> usize {
+    unsafe {
+        let mut ws = std::mem::MaybeUninit::<libc::winsize>::uninit();
+        if libc::ioctl(libc::STDOUT_FILENO, libc::TIOCGWINSZ, ws.as_mut_ptr()) == 0 {
+            let w = ws.assume_init().ws_col as usize;
+            if w > 0 { w } else { 80 }
+        } else {
+            80
+        }
+    }
+}
+
+fn fit_label(label: &str, width: usize) -> String {
+    let len = label.chars().count();
+    if len > width {
+        truncate(label, width.saturating_sub(1))
+    } else {
+        format!("{label:<width$}")
+    }
+}
+
 // ── constants ──────────────────────────────────────────────────────
 
 /// Maximum visible characters for a tool preview inside brackets.
@@ -231,17 +252,27 @@ pub(crate) fn format_tool_heartbeat(label: &str, elapsed: Duration) -> String {
 }
 
 /// Inline spinner line for an active tool — overwrites current line via `\r`.
+/// Truncates or pads the label so the total visible width fits within one
+/// terminal row, preventing line-wrap that breaks `\r` overwrite.
 pub(crate) fn format_tool_spinner(label: &str, elapsed: Duration, tick: u32) -> String {
     let frame = spinner_frame(tick);
     let dur = format_duration(elapsed);
-    format!("\r\x1b[2K\x1b[2m  {frame} {label:<50} {dur}\x1b[0m")
+    let width = terminal_width();
+    // visible layout: "  {frame} {label} {dur}" — 5 fixed chars + dur
+    let label_width = width.saturating_sub(5 + dur.len());
+    let fitted = fit_label(label, label_width);
+    format!("\r\x1b[2K\x1b[2m  {frame} {fitted} {dur}\x1b[0m")
 }
 
 /// Final completion line — clears spinner and writes ✓/✗ with newline.
 pub(crate) fn format_tool_done(label: &str, elapsed: Duration, is_error: bool) -> String {
     let icon = if is_error { '✗' } else { '✓' };
     let dur = format_duration(elapsed);
-    format!("\r\x1b[2K\x1b[2m  {icon} {label:<50} {dur}\x1b[0m\n")
+    let width = terminal_width();
+    // visible layout: "  {icon} {label} {dur}" — 5 fixed chars + dur
+    let label_width = width.saturating_sub(5 + dur.len());
+    let fitted = fit_label(label, label_width);
+    format!("\r\x1b[2K\x1b[2m  {icon} {fitted} {dur}\x1b[0m\n")
 }
 
 /// Inline thinking spinner — overwrites current line with a brightness
@@ -296,7 +327,11 @@ pub(crate) fn clear_thinking_line() -> String {
 /// running. No newline — the matching `format_worker_done` overwrites
 /// this line on completion.
 pub(crate) fn format_worker_start(worker_id: u32, prompt_preview: &str) -> String {
-    let label = truncate(&sanitize_label_field(prompt_preview), 60);
+    let width = terminal_width();
+    // visible: "  ⠋ w{id}  {label}" — 7 fixed chars + id digits
+    let id_len = if worker_id == 0 { 1 } else { (worker_id as f64).log10() as usize + 1 };
+    let label_cap = width.saturating_sub(7 + id_len);
+    let label = truncate(&sanitize_label_field(prompt_preview), label_cap);
     format!("\r\x1b[2K\x1b[2m  ⠋ w{worker_id}  {label}\x1b[0m")
 }
 
@@ -311,7 +346,11 @@ pub(crate) fn format_worker_done(
 ) -> String {
     let icon = if is_error { '✗' } else { '✓' };
     let dur = format_duration(elapsed);
-    let label = truncate(&sanitize_label_field(prompt_preview), 60);
+    let width = terminal_width();
+    // visible: "  {icon} w{id}  {label}  {dur}" — 9 fixed chars + id digits + dur
+    let id_len = if worker_id == 0 { 1 } else { (worker_id as f64).log10() as usize + 1 };
+    let label_cap = width.saturating_sub(9 + id_len + dur.len());
+    let label = truncate(&sanitize_label_field(prompt_preview), label_cap);
     format!("\r\x1b[2K\x1b[2m  {icon} w{worker_id}  {label}  {dur}\x1b[0m\n")
 }
 

--- a/crates/core/src/tool_display.rs
+++ b/crates/core/src/tool_display.rs
@@ -7,16 +7,17 @@ use serde_json::Value;
 use std::sync::OnceLock;
 use std::time::Duration;
 
+/// Current terminal column count, used to fit spinner labels within
+/// one row (otherwise `\r` overwrite breaks on line-wrap — see #138).
+/// Returns 80 when stdout isn't a tty or the OS query fails. The
+/// `terminal_size` crate wraps `TIOCGWINSZ` on Unix and
+/// `GetConsoleScreenBufferInfo` on Windows so we don't have to
+/// hand-roll cross-platform unsafe.
 fn terminal_width() -> usize {
-    unsafe {
-        let mut ws = std::mem::MaybeUninit::<libc::winsize>::uninit();
-        if libc::ioctl(libc::STDOUT_FILENO, libc::TIOCGWINSZ, ws.as_mut_ptr()) == 0 {
-            let w = ws.assume_init().ws_col as usize;
-            if w > 0 { w } else { 80 }
-        } else {
-            80
-        }
-    }
+    terminal_size::terminal_size()
+        .map(|(w, _)| w.0 as usize)
+        .filter(|w| *w > 0)
+        .unwrap_or(80)
 }
 
 fn fit_label(label: &str, width: usize) -> String {

--- a/crates/core/src/tool_display.rs
+++ b/crates/core/src/tool_display.rs
@@ -20,6 +20,9 @@ fn terminal_width() -> usize {
 }
 
 fn fit_label(label: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
     let len = label.chars().count();
     if len > width {
         truncate(label, width.saturating_sub(1))
@@ -329,7 +332,7 @@ pub(crate) fn clear_thinking_line() -> String {
 pub(crate) fn format_worker_start(worker_id: u32, prompt_preview: &str) -> String {
     let width = terminal_width();
     // visible: "  ⠋ w{id}  {label}" — 7 fixed chars + id digits
-    let id_len = if worker_id == 0 { 1 } else { (worker_id as f64).log10() as usize + 1 };
+    let id_len = worker_id.to_string().len();
     let label_cap = width.saturating_sub(7 + id_len);
     let label = truncate(&sanitize_label_field(prompt_preview), label_cap);
     format!("\r\x1b[2K\x1b[2m  ⠋ w{worker_id}  {label}\x1b[0m")
@@ -348,7 +351,7 @@ pub(crate) fn format_worker_done(
     let dur = format_duration(elapsed);
     let width = terminal_width();
     // visible: "  {icon} w{id}  {label}  {dur}" — 9 fixed chars + id digits + dur
-    let id_len = if worker_id == 0 { 1 } else { (worker_id as f64).log10() as usize + 1 };
+    let id_len = worker_id.to_string().len();
     let label_cap = width.saturating_sub(9 + id_len + dur.len());
     let label = truncate(&sanitize_label_field(prompt_preview), label_cap);
     format!("\r\x1b[2K\x1b[2m  {icon} w{worker_id}  {label}  {dur}\x1b[0m\n")


### PR DESCRIPTION
## Summary

- Tool spinner lines (braille animation during MCP calls) used a hardcoded `{label:<50}` padding, producing ~57 visible characters per line
- When the terminal/tmux pane is narrower (e.g. 56 columns), the line wraps — `\r` only returns to column 0 of the **wrapped** line, so previous frames accumulate as separate lines instead of animating in-place
- Now queries terminal width via `ioctl(TIOCGWINSZ)` (libc already a dependency) and dynamically sizes the label to fit within one row
- Applies to `format_tool_spinner`, `format_tool_done`, `format_worker_start`, `format_worker_done`

## Test plan

- [x] `cargo check -p thclaws-core` — compiles clean
- [x] `cargo test -p thclaws-core --lib -- tool_display` — 29 tests pass
- [ ] Manual: resize tmux pane to 40-60 columns, run MCP tool call, verify spinner animates in-place
- [ ] Manual: verify wide terminals (120+ cols) still show full labels with padding

Fixes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)