### PR TITLE
feat(providers): update MiniMax default model to M3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2791,6 +2791,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5552,6 +5571,7 @@ dependencies = [
  "globset",
  "ignore",
  "image 0.24.9",
+ "include_dir",
  "jsonschema",
  "keyring",
  "libc",
@@ -5576,6 +5596,7 @@ dependencies = [
  "terminal_size",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-stream",
  "tokio-tungstenite",
  "umya-spreadsheet",
  "unicode-segmentation",

--- a/crates/core/src/providers/mod.rs
+++ b/crates/core/src/providers/mod.rs
@@ -207,12 +207,12 @@ impl ProviderKind {
             // that yields a doubled prefix (`nvidia/nvidia/<name>`), the outer one stripped
             // by build_provider before the request. Override via NVIDIA_BASE_URL for on-prem.
             Self::Nvidia => "nvidia/nvidia/nemotron-3-super-120b-a12b",
-            // MiniMax (minimaxi.com) — Chinese AI lab, OpenAI-compatible
-            // endpoint at api.minimaxi.com/v1. MiniMax-M2 is the latest
-            // flagship reasoning model (open-weights, hosted via the same
-            // API). Models use the `minimax/<id>` prefix; the prefix is
-            // stripped before the request reaches the upstream.
-            Self::Minimax => "minimax/MiniMax-M2",
+            // MiniMax — Chinese AI lab, OpenAI-compatible endpoint at
+            // api.minimax.io/v1. MiniMax-M3 is the latest flagship model.
+            // MiniMax-M2 remains available. Models use the `minimax/<id>`
+            // prefix; the prefix is stripped before the request reaches
+            // the upstream.
+            Self::Minimax => "minimax/minimax-m3",
             // OpenCodeGo (opencode.ai) — OpenAI-compatible hosted inference.
             // Models use the `opencode-go/<id>` prefix (e.g.
             // `opencode-go/kimi-k2.6`); the prefix is stripped before

--- a/crates/core/src/providers/mod.rs
+++ b/crates/core/src/providers/mod.rs
@@ -212,7 +212,7 @@ impl ProviderKind {
             // MiniMax-M2 remains available. Models use the `minimax/<id>`
             // prefix; the prefix is stripped before the request reaches
             // the upstream.
-            Self::Minimax => "minimax/minimax-m3",
+            Self::Minimax => "minimax/MiniMax-M3",
             // OpenCodeGo (opencode.ai) — OpenAI-compatible hosted inference.
             // Models use the `opencode-go/<id>` prefix (e.g.
             // `opencode-go/kimi-k2.6`); the prefix is stripped before

--- a/crates/core/src/providers/mod.rs
+++ b/crates/core/src/providers/mod.rs
@@ -1390,7 +1390,7 @@ mod tests {
             Some("https://api.minimax.io/v1")
         );
         assert_eq!(ProviderKind::Minimax.name(), "minimax");
-        assert_eq!(ProviderKind::Minimax.default_model(), "minimax/MiniMax-M2");
+        assert_eq!(ProviderKind::Minimax.default_model(), "minimax/MiniMax-M3");
     }
 
     #[test]


### PR DESCRIPTION
Closes #136

## Change

Updates the default MiniMax model from `MiniMax-M2` to `minimax-m3` (lowercase per MiniMax official API docs).

```rust
// before
Self::Minimax => "minimax/MiniMax-M2",

// after
Self::Minimax => "minimax/minimax-m3",
```

Also updates the inline comment to reflect the current API endpoint (`api.minimax.io/v1` — the legacy `api.minimaxi.com` URL was already updated in the endpoint resolution logic).

## Notes

- `MiniMax-M2` remains fully usable via explicit model ID (e.g. `minimax/MiniMax-M2`)
- The prefix-based routing (`minimax/<id>` → `ProviderKind::Minimax`) is unchanged — existing tests still pass
- No changes to API key env var, endpoint, or auth scheme