### PR TITLE
fix(terminal): reset cursorPos on line clear events

### DIFF
--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -323,6 +323,7 @@ export function TerminalView({ active, modalOpen }: Props) {
             term.write("\x1b[2K\r");
             writePrompt();
             lineBuffer = "";
+            cursorPos = 0;
             recomputeSlash();
             return false;
           }
@@ -805,6 +806,7 @@ export function TerminalView({ active, modalOpen }: Props) {
         term.clear();
         writePrompt();
         lineBuffer = "";
+        cursorPos = 0;
         pendingAskId = null;
       } else if (
         msg.type === "terminal_history_replaced" &&


### PR DESCRIPTION
## Summary
- Fix `cursorPos` not being reset in two places where `lineBuffer` was cleared: Escape key dismissing the slash-command popup, and the backend `terminal_clear` event
- Stale `cursorPos` caused the visual caret to drift past the actual text on the next keystroke — character inserted correctly but cursor feedback was wrong

## Details
Two handlers cleared `lineBuffer` without resetting `cursorPos`. The Ctrl+C handler already had `cursorPos = 0` — these two spots were the only ones missing it.

## Test plan
- [ ] Type a slash command (`/hel`), press Escape, type a character — cursor should be at position 1
- [ ] Press Ctrl+L or trigger a terminal clear, type — cursor should be at position 1
- [ ] `pnpm run build` passes

Generated with [Clew Code](https://claude.com/clew-code)