### PR TITLE
fix(gui-shell): escape </ in injected values to prevent HTML script breakout

### DIFF
--- a/crates/core/src/gui_shell/serve.rs
+++ b/crates/core/src/gui_shell/serve.rs
@@ -305,8 +305,9 @@ pub fn inject_inline_bridge_with_id(html: &[u8], shell_id: &str) -> Vec<u8> {
         .unwrap_or_else(|_| "\"\"".into())
         .replace("</", "<\\/");
     let bridge_safe = bridge.replace("</", "<\\/");
-    let injection =
-        format!("<script>window.__thclaws_shell_id={id_json};</script><script>{bridge_safe}</script>");
+    let injection = format!(
+        "<script>window.__thclaws_shell_id={id_json};</script><script>{bridge_safe}</script>"
+    );
     let lower = html.to_ascii_lowercase();
     if let Some(idx) = find_subslice(&lower, b"<head>") {
         let insert_at = idx + b"<head>".len();

--- a/crates/core/src/gui_shell/serve.rs
+++ b/crates/core/src/gui_shell/serve.rs
@@ -301,9 +301,12 @@ pub fn serve_shell_index_inline(shell: &ShellRef) -> Response<Body> {
 /// includes everything, so `parts[0] === "gui-shell"` is false).
 pub fn inject_inline_bridge_with_id(html: &[u8], shell_id: &str) -> Vec<u8> {
     let bridge = super::BRIDGE_RUNTIME;
-    let id_json = serde_json::to_string(shell_id).unwrap_or_else(|_| "\"\"".into());
+    let id_json = serde_json::to_string(shell_id)
+        .unwrap_or_else(|_| "\"\"".into())
+        .replace("</", "<\\/");
+    let bridge_safe = bridge.replace("</", "<\\/");
     let injection =
-        format!("<script>window.__thclaws_shell_id={id_json};</script><script>{bridge}</script>");
+        format!("<script>window.__thclaws_shell_id={id_json};</script><script>{bridge_safe}</script>");
     let lower = html.to_ascii_lowercase();
     if let Some(idx) = find_subslice(&lower, b"<head>") {
         let insert_at = idx + b"<head>".len();
@@ -362,9 +365,9 @@ pub fn inject_mode_b_head_with(
     // but with an extra inline <script> before the bridge.
     let marker = format!(
         "<script>window.__thclaws_shell_mode=\"ws\";window.__thclaws_shell_ws_url={};window.__thclaws_shell_id={};window.__thclaws_shell_session_id={};</script>",
-        serde_json::to_string(ws_url).unwrap_or_else(|_| "\"\"".into()),
-        serde_json::to_string(shell_id).unwrap_or_else(|_| "\"\"".into()),
-        serde_json::to_string(session_id).unwrap_or_else(|_| "\"\"".into()),
+        serde_json::to_string(ws_url).unwrap_or_else(|_| "\"\"".into()).replace("</", "<\\/"),
+        serde_json::to_string(shell_id).unwrap_or_else(|_| "\"\"".into()).replace("</", "<\\/"),
+        serde_json::to_string(session_id).unwrap_or_else(|_| "\"\"".into()).replace("</", "<\\/"),
     );
     let bridge_src = format!(
         "<script src=\"{}/__bridge.js\"></script>",


### PR DESCRIPTION
## Summary
- `inject_inline_bridge_with_id` and `inject_mode_b_head_with` embed user-controlled values (`shell_id`, `session_id`, `ws_url`) and the bridge runtime into `<script>` tags via `serde_json::to_string`
- JSON escaping does not escape `</`, so a `shell_id` containing e.g. `</script>` would close the `<script>` tag prematurely, breaking the page
- Fix: `.replace("</", "<\/")` on each injected value — `<\/` is valid in both JSON and JavaScript but invisible to the HTML parser

## Test plan
- [ ] `cargo check -p thclaws-core --features gui`
- [ ] `cargo test -p thclaws-core --features gui`
- [ ] Manual: create a test shell directory with `>` in the name, verify the bridge loads correctly

Generated with [Clew Code](https://claude.com/clew-code)