### PR TITLE
fix(opencode-go): add minimax-m3 and qwen3.7 to wire-format routing

### DIFF
--- a/crates/core/src/providers/opencode_go.rs
+++ b/crates/core/src/providers/opencode_go.rs
@@ -28,8 +28,8 @@ pub const MODELS_URL: &str = "https://opencode.ai/zen/go/v1/models";
 // qwen4.x release doesn't silently fall through to the OpenAI path
 // and get rejected with a 4xx upstream. Tracked as a TODO so we can
 // rip out the lists once the upstream exposes the hint.
-const ANTHROPIC_MODELS: &[&str] = &["minimax-m2.5", "minimax-m2.7"];
-const ALIBABA_MODELS: &[&str] = &["qwen3.5-plus", "qwen3.6-plus"];
+const ANTHROPIC_MODELS: &[&str] = &["minimax-m2.5", "minimax-m2.7", "minimax-m3"];
+const ALIBABA_MODELS: &[&str] = &["qwen3.5-plus", "qwen3.6-plus", "qwen3.7-max", "qwen3.7-plus"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum WireFormat {
@@ -1087,12 +1087,15 @@ mod tests {
     fn test_detect_wire_format_anthropic() {
         assert_eq!(detect_wire_format("minimax-m2.7"), WireFormat::Anthropic);
         assert_eq!(detect_wire_format("minimax-m2.5"), WireFormat::Anthropic);
+        assert_eq!(detect_wire_format("minimax-m3"), WireFormat::Anthropic);
     }
 
     #[test]
     fn test_detect_wire_format_alibaba() {
         assert_eq!(detect_wire_format("qwen3.6-plus"), WireFormat::Alibaba);
         assert_eq!(detect_wire_format("qwen3.5-plus"), WireFormat::Alibaba);
+        assert_eq!(detect_wire_format("qwen3.7-max"), WireFormat::Alibaba);
+        assert_eq!(detect_wire_format("qwen3.7-plus"), WireFormat::Alibaba);
     }
 
     #[test]

--- a/crates/core/src/providers/opencode_go.rs
+++ b/crates/core/src/providers/opencode_go.rs
@@ -29,7 +29,12 @@ pub const MODELS_URL: &str = "https://opencode.ai/zen/go/v1/models";
 // and get rejected with a 4xx upstream. Tracked as a TODO so we can
 // rip out the lists once the upstream exposes the hint.
 const ANTHROPIC_MODELS: &[&str] = &["minimax-m2.5", "minimax-m2.7", "minimax-m3"];
-const ALIBABA_MODELS: &[&str] = &["qwen3.5-plus", "qwen3.6-plus", "qwen3.7-max", "qwen3.7-plus"];
+const ALIBABA_MODELS: &[&str] = &[
+    "qwen3.5-plus",
+    "qwen3.6-plus",
+    "qwen3.7-max",
+    "qwen3.7-plus",
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum WireFormat {


### PR DESCRIPTION
## Change

Adds `minimax-m3`, `qwen3.7-max`, and `qwen3.7-plus` to the wire-format routing tables in `opencode_go.rs`.

```rust
// before
const ANTHROPIC_MODELS: &[&str] = &["minimax-m2.5", "minimax-m2.7"];
const ALIBABA_MODELS: &[&str] = &["qwen3.5-plus", "qwen3.6-plus"];

// after
const ANTHROPIC_MODELS: &[&str] = &["minimax-m2.5", "minimax-m2.7", "minimax-m3"];
const ALIBABA_MODELS: &[&str] = &["qwen3.5-plus", "qwen3.6-plus", "qwen3.7-max", "qwen3.7-plus"];
```

## Why

Both models appear in `model_catalogue.json` (minimax-m3 verified 2026-06-02, qwen3.7-max/plus verified 2026-06-04) but were missing from the routing tables. Without an entry they fall through to the OpenAI path and get rejected with a 4xx upstream — the comment at line 27 already called this out as the failure mode.

- MiniMax M3 uses Anthropic wire format (consistent with M2.5/M2.7)
- Qwen3.7-max/plus use Alibaba wire format (consistent with qwen3.5/3.6-plus)

## Tests

Extended `test_detect_wire_format_anthropic` and `test_detect_wire_format_alibaba` with the three new model IDs.

```
test providers::opencode_go::tests::test_detect_wire_format_alibaba ... ok
test providers::opencode_go::tests::test_detect_wire_format_anthropic ... ok
```

All 9 unit tests pass (`cargo test -p thclaws-core --lib providers::opencode_go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)