### PR TITLE
feat(providers/opencode_go): lazy wire-hint cache — auto-discover routing from /v1/models

### DIFF
--- a/crates/core/src/providers/opencode_go.rs
+++ b/crates/core/src/providers/opencode_go.rs
@@ -18,6 +18,8 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use reqwest::Client;
 use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::sync::OnceLock;
 
 pub const DEFAULT_API_URL: &str = "https://opencode.ai/zen/go/v1";
 pub const MODELS_URL: &str = "https://opencode.ai/zen/go/v1/models";
@@ -64,6 +66,14 @@ fn detect_wire_format(model: &str) -> WireFormat {
     }
 }
 
+fn detect_wire_format_with_hints(model: &str, hints: &HashMap<String, WireFormat>) -> WireFormat {
+    let lower = model.to_lowercase();
+    if let Some(&fmt) = hints.get(&lower) {
+        return fmt;
+    }
+    detect_wire_format(model)
+}
+
 fn endpoint_for(format: WireFormat) -> &'static str {
     match format {
         WireFormat::OpenAI => "/chat/completions",
@@ -77,6 +87,7 @@ pub struct OpencodeGoProvider {
     api_key: String,
     base_url: String,
     list_models_url: Option<String>,
+    wire_cache: OnceLock<HashMap<String, WireFormat>>,
 }
 
 impl OpencodeGoProvider {
@@ -86,16 +97,19 @@ impl OpencodeGoProvider {
             api_key: api_key.into(),
             base_url: DEFAULT_API_URL.to_string(),
             list_models_url: None,
+            wire_cache: OnceLock::new(),
         }
     }
 
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = url.into();
+        self.wire_cache = OnceLock::new();
         self
     }
 
     pub fn with_list_models_url(mut self, url: impl Into<String>) -> Self {
         self.list_models_url = Some(url.into());
+        self.wire_cache = OnceLock::new();
         self
     }
 
@@ -855,6 +869,44 @@ impl OpencodeGoProvider {
         }
         format!("{}/models", self.base_url.trim_end_matches('/'))
     }
+
+    async fn load_wire_hints(&self) -> HashMap<String, WireFormat> {
+        let url = self.models_list_url();
+        let Ok(resp) = self
+            .client
+            .get(&url)
+            .header("authorization", format!("Bearer {}", self.api_key))
+            .send()
+            .await
+        else {
+            return HashMap::new();
+        };
+        let Ok(v) = resp.json::<Value>().await else {
+            return HashMap::new();
+        };
+        let mut hints = HashMap::new();
+        if let Some(arr) = v.get("data").and_then(Value::as_array) {
+            for m in arr {
+                let Some(raw_id) = m.get("id").and_then(Value::as_str) else {
+                    continue;
+                };
+                let model_id = raw_id
+                    .strip_prefix("opencode-go/")
+                    .unwrap_or(raw_id)
+                    .to_lowercase();
+                let Some(wire_str) = m.get("wire").and_then(Value::as_str) else {
+                    continue;
+                };
+                let format = match wire_str {
+                    "anthropic" => WireFormat::Anthropic,
+                    "alibaba" => WireFormat::Alibaba,
+                    _ => WireFormat::OpenAI,
+                };
+                hints.insert(model_id, format);
+            }
+        }
+        hints
+    }
 }
 
 #[async_trait]
@@ -910,7 +962,12 @@ impl Provider for OpencodeGoProvider {
             req.model = rest.to_string();
         }
 
-        let wire_format = detect_wire_format(&req.model);
+        let hints = self.wire_cache.get_or_init(|| {
+            tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(self.load_wire_hints())
+            })
+        });
+        let wire_format = detect_wire_format_with_hints(&req.model, hints);
         let endpoint = format!(
             "{}{}",
             self.base_url.trim_end_matches('/'),
@@ -1079,6 +1136,63 @@ fn extract_images(content: &ToolResultContent) -> Vec<(String, String)> {
 mod tests {
     use super::*;
     use crate::types::Message;
+
+    #[test]
+    fn hints_override_static_lists() {
+        let mut hints = HashMap::new();
+        hints.insert("minimax-m4".to_string(), WireFormat::Anthropic);
+        hints.insert("qwen5-ultra".to_string(), WireFormat::Alibaba);
+        // model ใหม่ที่ไม่อยู่ใน static list — ได้ hint จาก API
+        assert_eq!(
+            detect_wire_format_with_hints("minimax-m4", &hints),
+            WireFormat::Anthropic
+        );
+        assert_eq!(
+            detect_wire_format_with_hints("qwen5-ultra", &hints),
+            WireFormat::Alibaba
+        );
+        // model เก่าที่ไม่อยู่ใน hints — fallback static list
+        assert_eq!(
+            detect_wire_format_with_hints("minimax-m2.7", &HashMap::new()),
+            WireFormat::Anthropic
+        );
+        // unknown → OpenAI
+        assert_eq!(
+            detect_wire_format_with_hints("glm-5.1", &hints),
+            WireFormat::OpenAI
+        );
+    }
+
+    #[tokio::test]
+    async fn load_wire_hints_empty_on_bad_json() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "data": [{"id": "minimax-m4"}]  // no "wire" field
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let provider = OpencodeGoProvider::new("test-key")
+            .with_list_models_url(format!("{}/v1/models", server.uri()));
+        let hints = provider.load_wire_hints().await;
+        assert!(hints.is_empty());
+        // fallback static list still works when hints are empty
+        assert_eq!(
+            detect_wire_format_with_hints("minimax-m2.7", &hints),
+            WireFormat::Anthropic
+        );
+        assert_eq!(
+            detect_wire_format_with_hints("glm-5.1", &hints),
+            WireFormat::OpenAI
+        );
+    }
 
     #[test]
     fn test_detect_wire_format_openai() {

--- a/crates/core/src/providers/opencode_go.rs
+++ b/crates/core/src/providers/opencode_go.rs
@@ -1171,11 +1171,9 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/v1/models"))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                    "data": [{"id": "minimax-m4"}]  // no "wire" field
-                })),
-            )
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [{"id": "minimax-m4"}]  // no "wire" field
+            })))
             .mount(&server)
             .await;
 


### PR DESCRIPTION
## Summary

- เพิ่ม `wire_cache: OnceLock<HashMap<String, WireFormat>>` ใน `OpencodeGoProvider`
- `stream()` probe `/v1/models` ครั้งแรก → cache wire hints ไว้ตลอด process
- `detect_wire_format_with_hints()` ใช้ hint จาก API ก่อน แล้ว fallback ไป static lists
- model ใหม่ที่มี `"wire"` field (เช่น `minimax-m3.1`, `qwen4.x`) route ถูกต้องโดยไม่ต้อง code change
- probe fail หรือ API ไม่มี `wire` field → silent fallback ไม่ error

## Design choices

- `std::sync::OnceLock` + `tokio::task::block_in_place` (multi-thread runtime ที่ thClaws ใช้อยู่)
- Static lists ยังอยู่ครบ — backward compat + offline usage
- `with_base_url()` / `with_list_models_url()` reset cache เพื่อป้องกัน stale hints

## Test plan

- [x] `cargo test -p thclaws-core providers::opencode_go` — 11 passed, 2 ignored (live)
  - `hints_override_static_lists` — model ใหม่จาก API, fallback static list, unknown → OpenAI
  - `load_wire_hints_empty_on_bad_json` — wiremock: ไม่มี `wire` field → hints ว่าง → fallback ทำงาน
  - existing tests `test_detect_wire_format_*` ผ่านทั้งหมด

🤖 Generated with [Claude Code](https://claude.com/claude-code)