### PR TITLE
Add Atlas Cloud provider support

### DIFF
--- a/crates/core/resources/model_catalogue.json
+++ b/crates/core/resources/model_catalogue.json
@@ -7849,6 +7849,24 @@
           "verified_at": "2026-07-04"
         }
       }
+    },
+    "atlascloud": {
+      "list_url": "https://api.atlascloud.ai/v1/models",
+      "default_context": 1000000,
+      "models": {
+        "atlascloud/deepseek-ai/deepseek-v4-pro": {
+          "context": 1048576,
+          "max_output": 393216,
+          "source": "https://api.atlascloud.ai/api/v1/models (display_console Text model, live verified 2026-07-13)",
+          "verified_at": "2026-07-13"
+        },
+        "atlascloud/qwen/qwen3.5-flash": {
+          "context": 1000000,
+          "max_output": 67072,
+          "source": "https://api.atlascloud.ai/api/v1/models (display_console Text model, live verified 2026-07-13)",
+          "verified_at": "2026-07-13"
+        }
+      }
     }
   },
   "aliases": {},

--- a/crates/core/src/providers/mod.rs
+++ b/crates/core/src/providers/mod.rs
@@ -1730,6 +1730,7 @@ mod tests {
             ProviderKind::OpenAIResponses,
             ProviderKind::ChatGptCodex,
             ProviderKind::AgentSdk,
+            ProviderKind::AtlasCloud,
             ProviderKind::QwenCloud,
             ProviderKind::ThaiLLM,
             ProviderKind::Nvidia,
@@ -1896,8 +1897,14 @@ mod tests {
             ProviderKind::detect("atlascloud/deepseek-ai/deepseek-v4-pro"),
             Some(ProviderKind::AtlasCloud)
         );
-        assert_eq!(ProviderKind::AtlasCloud.api_key_env(), Some("ATLASCLOUD_API_KEY"));
-        assert_eq!(ProviderKind::AtlasCloud.endpoint_env(), Some("ATLASCLOUD_BASE_URL"));
+        assert_eq!(
+            ProviderKind::AtlasCloud.api_key_env(),
+            Some("ATLASCLOUD_API_KEY")
+        );
+        assert_eq!(
+            ProviderKind::AtlasCloud.endpoint_env(),
+            Some("ATLASCLOUD_BASE_URL")
+        );
         assert_eq!(
             ProviderKind::AtlasCloud.default_endpoint(),
             Some("https://api.atlascloud.ai/v1")
@@ -1909,6 +1916,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn detect_tokenrouter_prefix_routes_to_tokenrouter_provider() {
         // tokenrouter/ must be detected before the bare-vendor heuristics.
         assert_eq!(

--- a/crates/core/src/providers/mod.rs
+++ b/crates/core/src/providers/mod.rs
@@ -59,6 +59,7 @@ pub mod thclaws_gateway;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ProviderKind {
     Anthropic,
+    AtlasCloud,
     AgentSdk,
     OpenAI,
     OpenAIResponses,
@@ -205,6 +206,7 @@ impl ProviderKind {
 impl ProviderKind {
     pub const ALL: &'static [Self] = &[
         Self::Anthropic,
+        Self::AtlasCloud,
         Self::AgentSdk,
         Self::OpenAI,
         Self::OpenAIResponses,
@@ -234,6 +236,7 @@ impl ProviderKind {
     pub fn name(&self) -> &'static str {
         match self {
             Self::Anthropic => "anthropic",
+            Self::AtlasCloud => "atlascloud",
             Self::AgentSdk => "anthropic-agent",
             Self::OpenAI => "openai",
             Self::OpenAIResponses => "openai-responses",
@@ -264,6 +267,7 @@ impl ProviderKind {
     pub fn default_model(&self) -> &'static str {
         match self {
             Self::Anthropic => "claude-sonnet-4-6",
+            Self::AtlasCloud => "atlascloud/qwen/qwen3.5-flash",
             Self::AgentSdk => "agent/claude-sonnet-4-6",
             Self::OpenAI => "gpt-4.1",
             Self::OpenAIResponses => "codex/gpt-5.2-codex",
@@ -358,6 +362,7 @@ impl ProviderKind {
     pub fn endpoint_env(&self) -> Option<&'static str> {
         match self {
             Self::TokenRouter => Some("TOKENROUTER_BASE_URL"),
+            Self::AtlasCloud => Some("ATLASCLOUD_BASE_URL"),
             Self::DashScope => Some("DASHSCOPE_BASE_URL"),
             Self::QwenCloud => Some("QWENCLOUD_BASE_URL"),
             Self::Ollama => Some("OLLAMA_BASE_URL"),
@@ -400,6 +405,7 @@ impl ProviderKind {
     pub fn default_endpoint(&self) -> Option<&'static str> {
         match self {
             Self::TokenRouter => Some("https://api.tokenrouter.com/v1"),
+            Self::AtlasCloud => Some("https://api.atlascloud.ai/v1"),
             Self::DashScope => Some("https://dashscope.aliyuncs.com/compatible-mode/v1"),
             // International / Singapore region of DashScope.
             Self::QwenCloud => Some("https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
@@ -471,6 +477,7 @@ impl ProviderKind {
             Self::ChatGptCodex => None,
             Self::OpenRouter => Some("OPENROUTER_API_KEY"),
             Self::TokenRouter => Some("TOKENROUTER_API_KEY"),
+            Self::AtlasCloud => Some("ATLASCLOUD_API_KEY"),
             Self::Gemini => Some("GEMINI_API_KEY"),
             Self::Ollama => None,
             Self::OllamaAnthropic => None,
@@ -567,6 +574,7 @@ impl ProviderKind {
             // surprise-switching to a different provider.
             Self::OpenAI
             | Self::OpenAIResponses
+            | Self::AtlasCloud
             | Self::ChatGptCodex
             | Self::AgentSdk
             | Self::Ollama
@@ -599,6 +607,8 @@ impl ProviderKind {
             // Check openrouter/ first — it's the most specific prefix.
             // Models look like openrouter/anthropic/claude-sonnet-4-6.
             Some(Self::OpenRouter)
+        } else if model.starts_with("atlascloud/") {
+            Some(Self::AtlasCloud)
         } else if model.starts_with("tokenrouter/") {
             // TokenRouter (tokenrouter.com) — OpenAI-compatible unified
             // gateway. Models look like tokenrouter/anthropic/claude-sonnet-4.5;
@@ -1877,6 +1887,28 @@ mod tests {
     }
 
     #[test]
+    fn detect_atlascloud_prefix_routes_to_atlascloud_provider() {
+        assert_eq!(
+            ProviderKind::detect("atlascloud/qwen/qwen3.5-flash"),
+            Some(ProviderKind::AtlasCloud)
+        );
+        assert_eq!(
+            ProviderKind::detect("atlascloud/deepseek-ai/deepseek-v4-pro"),
+            Some(ProviderKind::AtlasCloud)
+        );
+        assert_eq!(ProviderKind::AtlasCloud.api_key_env(), Some("ATLASCLOUD_API_KEY"));
+        assert_eq!(ProviderKind::AtlasCloud.endpoint_env(), Some("ATLASCLOUD_BASE_URL"));
+        assert_eq!(
+            ProviderKind::AtlasCloud.default_endpoint(),
+            Some("https://api.atlascloud.ai/v1")
+        );
+        assert_eq!(ProviderKind::AtlasCloud.name(), "atlascloud");
+        assert_eq!(
+            ProviderKind::AtlasCloud.default_model(),
+            "atlascloud/qwen/qwen3.5-flash"
+        );
+    }
+
     fn detect_tokenrouter_prefix_routes_to_tokenrouter_provider() {
         // tokenrouter/ must be detected before the bare-vendor heuristics.
         assert_eq!(

--- a/crates/core/src/repl.rs
+++ b/crates/core/src/repl.rs
@@ -4295,6 +4295,24 @@ pub fn build_provider(config: &AppConfig) -> Result<Arc<dyn Provider>> {
             }
             Ok(Arc::new(provider))
         }
+        ProviderKind::AtlasCloud => {
+            // Atlas Cloud exposes an OpenAI-compatible LLM API. Model ids
+            // use the `atlascloud/<id>` routing prefix locally, stripped
+            // before the upstream request so Atlas sees ids such as
+            // `qwen/qwen3.5-flash` or `deepseek-ai/deepseek-v4-pro`.
+            let (key, url) = compat_endpoint(
+                config,
+                kind,
+                "ATLASCLOUD_BASE_URL",
+                "https://api.atlascloud.ai/v1",
+                api_key,
+            );
+            Ok(Arc::new(
+                OpenAIProvider::new(key)
+                    .with_base_url(url)
+                    .with_strip_model_prefix("atlascloud/"),
+            ))
+        }
         ProviderKind::TokenRouter => {
             // TokenRouter (tokenrouter.com) — OpenAI-compatible unified
             // gateway to 300+ models. Models use the


### PR DESCRIPTION
## Summary
- add Atlas Cloud as an additional OpenAI-compatible provider
- route atlascloud/<model> ids through the existing OpenAI provider adapter and strip the local prefix before upstream calls
- add Atlas Cloud text models to the model catalogue with live-verified context/output limits

## Validation
- inspected diff for provider routing, env/base URL wiring, and model catalogue entries
- parsed crates/core/resources/model_catalogue.json and verified Atlas Cloud entries

No README changes.
