### PR TITLE
docs: add optional Parallel Search MCP example

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,10 @@ thclaws
 ❯ /kms          # list attached knowledge bases
 ❯ /skill install https://github.com/anthropics/skills.git
 ❯ /mcp add github https://mcp.github.com
+
+# Optional web search and URL fetching (no API key or account needed)
+# User-provided search objectives, search queries, and requested URLs are sent to Parallel
+❯ /mcp add parallel-search https://search.parallel.ai/mcp
 ❯ ! git status  # shell escape
 
 # Concurrent and long-running work


### PR DESCRIPTION
## Summary

Add an optional Parallel Search MCP setup example to the README quick start.

## Motivation

The existing quick start demonstrates thClaws' native `/mcp add` workflow with GitHub. Adding a second opt-in example makes web search and URL fetching available through the same documented extension point without requiring an account or API key.

## Changes

- Add the `parallel-search` MCP command beside the existing GitHub MCP example.
- Disclose that user-provided search objectives, search queries, and requested URLs are sent to Parallel.
- Leave thClaws runtime behavior, providers, defaults, authentication, security, and trust behavior unchanged.

## Test plan

- [x] `git diff --check` passes.

## Screenshots / recordings

Documentation-only change; no GUI or CLI behavior changed.

## Checklist

- [x] Documentation updated.
- [x] PR scope is focused with no unrelated changes.
- [x] Commit follows the project style.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.