### PR TITLE
fix(team): strip verbatim UNC prefix from team-dir on Windows

### DIFF
--- a/crates/core/src/team.rs
+++ b/crates/core/src/team.rs
@@ -1626,6 +1626,19 @@ impl Tool for SpawnTeammateTool {
             })
             .to_string_lossy()
             .to_string();
+        // Windows: Path::canonicalize() ALWAYS returns a \\?\-prefixed
+        // UNC form (GetFinalPathNameByHandleW). The teammate process uses
+        // this team_dir for all mailbox/status/inbox I/O, and file ops on
+        // the \\?\ form silently fail - status never leaves "spawning",
+        // the inbox never drains, and the 8s liveness probe reports "never
+        // booted" even though the process runs. Strip the prefix so the
+        // child gets a plain drive path. (Spawning via a POSIX shell via
+        // THCLAWS_SHELL works only when the path has no \\?\ prefix.)
+        #[cfg(windows)]
+        let team_dir = team_dir
+            .strip_prefix(r"\\?\")
+            .map(str::to_string)
+            .unwrap_or(team_dir);
         let needs_cli = bin.ends_with("/thclaws") || bin.ends_with("\\thclaws");
         let cli_flag = if needs_cli { " --cli" } else { "" };
 


### PR DESCRIPTION
## Summary
On Windows, `SpawnTeammate` always fails: the child process never enters its poll loop, status stays `spawning`, and the GUI reports "launched but never booted" / "exited immediately". Output log tail: `The filename, directory name, or volume label syntax is incorrect.`

## Root cause (two layers)

**Layer 1 - POSIX escaping vs cmd.exe.** The spawn command is built as a shell string with `shell_escape()` (single-quote wrapping, team.rs ~1061) and executed via `shell_invocation()` which on Windows defaults to `cmd /C` (util.rs ~258). cmd.exe does not understand POSIX single quotes, so a path containing a space (`C:\Program Files\thClaws\bin\thclaws.exe` from `current_exe()`) breaks the token. Workaround: set `THCLAWS_SHELL` to a POSIX shell (e.g. Git Bash).

**Layer 2 - verbatim UNC prefix on team-dir.** The spawner passes `--team-dir` as `team_dir.canonicalize()`, and Rust canonicalize on Windows ALWAYS returns a verbatim (UNC) path starting with `\?\` (e.g. `\?\C:\Users\...`). The teammate uses that path for ALL mailbox/status/inbox file I/O, which silently fails - status never leaves `spawning`, the inbox never drains. Manual launch with the same command but a plain path (no verbatim prefix) works perfectly: status flips idle/working, messages are processed, replies reach the lead.

Isolation proof: identical command, only difference is the `\?\` prefix on `--team-dir` -> one works, one never writes status.

## Fix (attached patch)
Strip the verbatim prefix on Windows before building the spawn command:
```rust
#[cfg(windows)]
let team_dir = team_dir
    .strip_prefix(r"\?\")
    .map(str::to_string)
    .unwrap_or(team_dir);
```
Also consider raising BOOT_TIMEOUT (currently 8s) - on this machine a healthy boot (scheduler + api_v1 bind + session meta scans) can exceed 8s, so even fixed, the probe may time out.

## Environment
- thclaws 0.108.0 and 0.116.0 (reproduced on both, verified in main source)
- Windows 11, no tmux (falls to background-process spawn path)


Fixes #200
